### PR TITLE
Fix broken argument parsing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "35b76bf577d3cc74820f8991894ce3bcdf024ddc",
-          "version": "0.0.2"
+          "revision": "eb51f949cdd0c9d88abba9ce79d37eb7ea1231d0",
+          "version": "0.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .executable(name: "swiftframe", targets: ["SwiftFrame"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.2.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0")
     ],
     targets: [

--- a/Sources/SwiftFrame/main.swift
+++ b/Sources/SwiftFrame/main.swift
@@ -8,18 +8,28 @@ import ArgumentParser
 struct SwiftFrame: ParsableCommand {
 
     @Flag(help: "Prints additional information and lets you verify the config file before rendering")
-    var verbose: Bool
+    var verbose = false
 
     @Option(name: .shortAndLong, help: "Read configuration values from the specified file")
     var configPath: String
 
+    func run() throws {
+        runWrapped()
+    }
+
+    private func runWrapped() {
+        do {
+            let processor = try ConfigProcessor(filePath: configPath, verbose: verbose)
+            try processor.validate()
+            try processor.run()
+        } catch let error as NSError {
+            print(CommandLineFormatter.formatError(error.localizedDescription))
+            error.expectation.flatMap { print(CommandLineFormatter.formatWarning(title: "Expectation", text: $0)) }
+            error.actualValue.flatMap { print(CommandLineFormatter.formatWarning(title: "Actual", text: $0)) }
+            Darwin.exit(Int32(error.code))
+        }
+    }
+
 }
 
-// We need this small wrapper to retain out nicely formatted error logging
-ky_executeOrExit {
-    let instance = try SwiftFrame.parse()
-
-    let processor = try ConfigProcessor(filePath: instance.configPath, verbose: instance.verbose)
-    try processor.validate()
-    try processor.run()
-}
+SwiftFrame.main()


### PR DESCRIPTION
Currently, when executing the produced binary, the program fails with an error even when just using the `--help` flag.
I've updated the `ArgumentParser` package to the latest version and slightly refactored the way the binary is run