### PR TITLE
Support vertical text alignment

### DIFF
--- a/Example/example.config
+++ b/Example/example.config
@@ -59,7 +59,6 @@
       "textData": [
         {
           "identifier": "welcome-title",
-          "groupIdentifier": "iPhoneX",
           "topLeft": {
             "x": 66,
             "y": 2137
@@ -75,7 +74,6 @@
         },
         {
           "identifier": "button-callout",
-          "groupIdentifier": "iPhoneX",
           "topLeft": {
             "x": 2349,
             "y": 1811

--- a/Example/example.config
+++ b/Example/example.config
@@ -59,6 +59,7 @@
       "textData": [
         {
           "identifier": "welcome-title",
+          "groupIdentifier": "iPhoneX",
           "topLeft": {
             "x": 66,
             "y": 2137
@@ -67,10 +68,14 @@
             "x": 1059,
             "y": 2377
           },
-          "alignment": "center"
+          "alignment": {
+            "horizontal": "center",
+            "vertical": "top"
+          }
         },
         {
           "identifier": "button-callout",
+          "groupIdentifier": "iPhoneX",
           "topLeft": {
             "x": 2349,
             "y": 1811
@@ -80,7 +85,10 @@
             "y": 2171
           },
           "colorOverride": "#ff7518",
-          "alignment": "right"
+          "alignment": {
+            "horizontal": "right",
+            "vertical": "center"
+          }
         }
       ]
     },
@@ -140,7 +148,10 @@
             "x": 1882,
             "y": 2525
           },
-          "alignment": "center",
+          "alignment": {
+            "horizontal": "center",
+            "vertical": "center"
+          },
           "customFontPath": "/System/Library/Fonts/Avenir Next.ttc"
         },
         {
@@ -154,7 +165,10 @@
             "y": 2368
           },
           "colorOverride": "#ff7518",
-          "alignment": "right"
+          "alignment": {
+            "horizontal": "right",
+            "vertical": "bottom"
+          },
         }
       ]
     }

--- a/Example/example.yaml
+++ b/Example/example.yaml
@@ -49,7 +49,9 @@ deviceData:
         bottomRight:
           x: 1059
           y: 2377
-        alignment: center
+        alignment: 
+          horizontal: center
+          vertical: center
       - identifier: button-callout
         topLeft:
           x: 2349
@@ -58,7 +60,9 @@ deviceData:
           x: 3258
           y: 2171
         colorOverride: "#ff7518"
-        alignment: right
+        alignment: 
+          horizontal: right
+          vertical: center
   - outputSuffix: iPad Pro 12.9 inch
     screenshots: Example/Screenshots/iPad Pro/
     templateFile: Example/Template Files/iPad Pro TemplateFile.png
@@ -99,7 +103,9 @@ deviceData:
         bottomRight:
           x: 1882
           y: 2525
-        alignment: center
+        alignment: 
+          horizontal: right
+          vertical: center
         customFontPath: "/System/Library/Fonts/Avenir Next.ttc"
       - identifier: button-callout
         topLeft:
@@ -109,4 +115,6 @@ deviceData:
           x: 3154
           y: 2368
         colorOverride: "#ff7518"
-        alignment: right
+        alignment: 
+          horizontal: right
+          vertical: center

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "eb51f949cdd0c9d88abba9ce79d37eb7ea1231d0",
-          "version": "0.2.0"
+          "revision": "7255fd547f70468e19abbac5f7964f1ef309ad92",
+          "version": "0.2.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0")
     ],
     targets: [
-        .target(name: "SwiftFrame", dependencies: ["SwiftFrameCore", "ArgumentParser"]),
+        .target(name: "SwiftFrame", dependencies: ["SwiftFrameCore", .product(name: "ArgumentParser", package: "swift-argument-parser")]),
         .target(name: "SwiftFrameCore", dependencies: ["Yams"]),
         .testTarget(name: "SwiftFrameTests", dependencies: ["SwiftFrameCore"])
     ]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ To use SwiftFrame, you need to pass it a configuration file (which is a plain JS
   * `textData`: an array containing further information about text titles coordinates and its layout
     * `titleIdentifer`: the key that SwiftFrame should look for in the `.strings` file for a certain title
     * `textColorOverride`: **optional**, a color in Hex format to use specifically for this title
-    * `textAlignment`: the text alignment in CSS style (`left`, `right`, `center`, `justify` or `natural`)
+    * `textAlignment`: information about text alignment
+      * `horizontal`: the horizontal text alignment in CSS style (`left`, `right`, `center`, `justify` or `natural`)
+      * `vertical`: the vertical text alignment in (`top`, `center`, `bottom`)
     * `customFontPath`: **optional**, a path to a font file to use specifically for this title
     * `groupIdentifier`: **optional**, an identifier for a text group (see below)
     * `topLeft` and `bottomRight`: the bounding coordinate points of the text (as of right now, it's not possible to have rotated text)

--- a/Sources/SwiftFrame/main.swift
+++ b/Sources/SwiftFrame/main.swift
@@ -48,7 +48,7 @@ struct SwiftFrame: ParsableCommand {
             if !verbose {
                 print("Use --verbose to get additional error information")
             }
-            
+
             Darwin.exit(Int32(error.code))
         }
     }

--- a/Sources/SwiftFrame/main.swift
+++ b/Sources/SwiftFrame/main.swift
@@ -45,10 +45,6 @@ struct SwiftFrame: ParsableCommand {
             error.expectation.flatMap { print(CommandLineFormatter.formatWarning(title: "Expectation", text: $0)) }
             error.actualValue.flatMap { print(CommandLineFormatter.formatWarning(title: "Actual", text: $0)) }
 
-            if !verbose {
-                print("Use --verbose to get additional error information")
-            }
-
             Darwin.exit(Int32(error.code))
         }
     }

--- a/Sources/SwiftFrame/main.swift
+++ b/Sources/SwiftFrame/main.swift
@@ -18,7 +18,7 @@ struct SwiftFrame: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "swiftframe",
         abstract: "CLI application for speedy screenshot framing",
-        version: "2.2.0",
+        version: "2.3.0",
         helpNames: .shortAndLong)
 
     @Flag(name: .shortAndLong, help: "Prints additional information and lets you verify the config file before rendering")

--- a/Sources/SwiftFrame/main.swift
+++ b/Sources/SwiftFrame/main.swift
@@ -4,36 +4,25 @@ import Foundation
 import SwiftFrameCore
 import ArgumentParser
 
-extension URL: ExpressibleByArgument {
-
-    public init?(argument: String) {
-        self.init(fileURLWithPath: argument)
-    }
-
-}
-
-// Struct name serves as command name
 struct SwiftFrame: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "swiftframe",
         abstract: "CLI application for speedy screenshot framing",
-        version: "2.3.0",
+        version: "3.0.0",
         helpNames: .shortAndLong)
+
+    @Argument(help: "Read configuration values from the specified file", completion: .list(["config", "yml", "yaml"]))
+    var configFilePath: String
 
     @Flag(name: .shortAndLong, help: "Prints additional information and lets you verify the config file before rendering")
     var verbose = false
 
-    @Option(name: .shortAndLong, help: "Read configuration values from the specified file")
-    var configPath: URL
-
     func run() throws {
-        runWrapped()
-    }
+        let configFileURL = URL(fileURLWithPath: configFilePath)
 
-    private func runWrapped() {
         do {
-            let processor = try ConfigProcessor(configURL: configPath, verbose: verbose)
+            let processor = try ConfigProcessor(configURL: configFileURL, verbose: verbose)
             try processor.validate()
             try processor.run()
         } catch let error as NSError {

--- a/Sources/SwiftFrame/main.swift
+++ b/Sources/SwiftFrame/main.swift
@@ -37,9 +37,18 @@ struct SwiftFrame: ParsableCommand {
             try processor.validate()
             try processor.run()
         } catch let error as NSError {
-            print(CommandLineFormatter.formatError(error.localizedDescription))
+            let errorMessage = verbose
+                ? CommandLineFormatter.formatError(error.description)
+                : CommandLineFormatter.formatError(error.localizedDescription)
+            print(errorMessage)
+
             error.expectation.flatMap { print(CommandLineFormatter.formatWarning(title: "Expectation", text: $0)) }
             error.actualValue.flatMap { print(CommandLineFormatter.formatWarning(title: "Actual", text: $0)) }
+
+            if !verbose {
+                print("Use --verbose to get additional error information")
+            }
+            
             Darwin.exit(Int32(error.code))
         }
     }

--- a/Sources/SwiftFrameCore/Helper Types/TextAlignment.swift
+++ b/Sources/SwiftFrameCore/Helper Types/TextAlignment.swift
@@ -3,12 +3,15 @@ import Foundation
 
 struct TextAlignment: Codable, Equatable {
 
+    // MARK: - Nested Types
+
     enum Horizontal: String, Codable {
 
         case left
         case right
         case center
         case justify
+        case natural
 
         var nsAlignment: NSTextAlignment {
             switch self {
@@ -20,6 +23,8 @@ struct TextAlignment: Codable, Equatable {
                 return .center
             case .justify:
                 return .justified
+            case .natural:
+                return .natural
             }
         }
 
@@ -29,12 +34,9 @@ struct TextAlignment: Codable, Equatable {
         case top, center, bottom
     }
 
+    // MARK: - Properties
+
     let horizontal: Horizontal
     let vertical: Vertical
-
-    init(horizontal: Horizontal, vertical: Vertical) {
-        self.horizontal = horizontal
-        self.vertical = vertical
-    }
 
 }

--- a/Sources/SwiftFrameCore/Helper Types/TextAlignment.swift
+++ b/Sources/SwiftFrameCore/Helper Types/TextAlignment.swift
@@ -1,27 +1,40 @@
 import AppKit
 import Foundation
 
-enum TextAlignment: String, Codable {
+struct TextAlignment: Codable, Equatable {
 
-    case left
-    case right
-    case center
-    case justify
-    case inherit
+    enum Horizontal: String, Codable {
 
-    var nsAlignment: NSTextAlignment {
-        switch self {
-        case .left:
-            return .left
-        case .right:
-            return .right
-        case .center:
-            return .center
-        case .justify:
-            return .justified
-        case .inherit:
-            return .natural
+        case left
+        case right
+        case center
+        case justify
+
+        var nsAlignment: NSTextAlignment {
+            switch self {
+            case .left:
+                return .left
+            case .right:
+                return .right
+            case .center:
+                return .center
+            case .justify:
+                return .justified
+            }
         }
+
+    }
+
+    enum Vertical: String, Codable {
+        case top, center, bottom
+    }
+
+    let horizontal: Horizontal
+    let vertical: Vertical
+
+    init(horizontal: Horizontal, vertical: Vertical) {
+        self.horizontal = horizontal
+        self.vertical = vertical
     }
 
 }

--- a/Sources/SwiftFrameCore/Workers/TextRenderer.swift
+++ b/Sources/SwiftFrameCore/Workers/TextRenderer.swift
@@ -5,7 +5,7 @@ final class TextRenderer {
 
     private let minFontSize: CGFloat = 1
     static let pointSizeTolerance: CGFloat = 1e-7
-    static let verticalAlignmentPadding: CGFloat = 0.5
+    static let verticalAlignmentPadding: CGFloat = 1.2
 
     // MARK: - Frame Rendering
 
@@ -50,6 +50,7 @@ final class TextRenderer {
             originY = outerFrame.origin.y
         }
 
+        // We need to add a little bit of padding again, because CoreText has hiccups and struggles to render multi-line text into an exactly fitting rect
         return CGRect(x: originX, y: originY, width: innerFrame.width, height: innerFrame.height + TextRenderer.verticalAlignmentPadding)
     }
 

--- a/Sources/SwiftFrameCore/Workers/TextRenderer.swift
+++ b/Sources/SwiftFrameCore/Workers/TextRenderer.swift
@@ -9,6 +9,11 @@ final class TextRenderer {
     // MARK: - Frame Rendering
 
     func render(text: String, font: NSFont, color: NSColor, alignment: TextAlignment, rect: NSRect, context: CGContext) throws {
+        guard !text.isEmpty else {
+            print(CommandLineFormatter.formatWarning(text: "String was emtpy and will not be rendered"))
+            return
+        }
+
         let attributedString = try makeAttributedString(for: text, font: font, color: color, alignment: alignment)
 
         context.saveGState()
@@ -61,7 +66,9 @@ final class TextRenderer {
     /// particular number of lines
     func maximumFontSizeThatFits(string: String, font: NSFont, alignment: TextAlignment, maxSize: CGFloat, size: CGSize) throws -> CGFloat {
         guard !string.isEmpty else {
-            throw NSError(description: "Empty string was passed to TextRenderer")
+            // Will be skipped during rendering anyways and won't affect text group's max size negatively, so it's okay to
+            // return maxSize here
+            return maxSize
         }
 
         let calculatedFontSize = try maxFontSizeThatFits(

--- a/Sources/SwiftFrameCore/Workers/TextRenderer.swift
+++ b/Sources/SwiftFrameCore/Workers/TextRenderer.swift
@@ -13,11 +13,6 @@ final class TextRenderer {
 
         context.saveGState()
 
-        context.setStrokeColor(NSColor.red.cgColor)
-        context.setLineWidth(2)
-        context.addRect(rect)
-        context.drawPath(using: .stroke)
-
         let frame = try makeFrame(from: attributedString, in: rect, alignment: alignment)
         CTFrameDraw(frame, context)
         context.restoreGState()

--- a/Sources/SwiftFrameCore/Workers/TextRenderer.swift
+++ b/Sources/SwiftFrameCore/Workers/TextRenderer.swift
@@ -23,21 +23,14 @@ final class TextRenderer {
         context.restoreGState()
     }
 
-    private func makeFrame(from attributedText: NSAttributedString, in rect: NSRect, alignment: TextAlignment) throws -> CTFrame {
-        let frameSetter = CTFramesetterCreateWithAttributedString(attributedText)
-
-        let textSize = CTFramesetterSuggestFrameSizeWithConstraints(
-            frameSetter,
-            CFRange(location: 0, length: attributedText.length),
-            nil,
-            rect.size,
-            nil
-        )
+    private func makeFrame(from attributedString: NSAttributedString, in rect: NSRect, alignment: TextAlignment) throws -> CTFrame {
+        let textSize = attributedStringSize(attributedString, maxWidth: rect.width)
+        let framesetter = CTFramesetterCreateWithAttributedString(attributedString)
 
         let alignedRect = try calculateAlignedRect(size: textSize, outerFrame: rect, alignment: alignment)
         let path = CGPath(rect: alignedRect, transform: nil)
 
-        return CTFramesetterCreateFrame(frameSetter, CFRange(location: 0, length: attributedText.length), path, nil)
+        return CTFramesetterCreateFrame(framesetter, CFRange(location: 0, length: attributedString.length), path, nil)
     }
 
     func calculateAlignedRect(size: CGSize, outerFrame: CGRect, alignment: TextAlignment) throws -> CGRect {

--- a/Tests/SwiftFrameTests/RegexMatchTests.swift
+++ b/Tests/SwiftFrameTests/RegexMatchTests.swift
@@ -56,7 +56,7 @@ class RegexMatchTests: XCTestCase {
 
 // with this wrapper method we can make tests fail and return a boolean at the same time
 // since simply asserting would not stop the test
-fileprivate func ky_assertEqual<T: Equatable>(_ value1: T, _ value2: T) -> Bool {
+private func ky_assertEqual<T: Equatable>(_ value1: T, _ value2: T) -> Bool {
     if value1 != value2 {
         XCTFail("\(value1) is not equal to \(value2)")
     }

--- a/Tests/SwiftFrameTests/TextRendererTests.swift
+++ b/Tests/SwiftFrameTests/TextRendererTests.swift
@@ -53,7 +53,7 @@ class TextRendererTests: XCTestCase {
         let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .bottom))
 
         XCTAssertEqual(alignedRect.origin, rect.origin)
-        XCTAssertEqual(alignedRect.height, size.height + TextRenderer.verticalAlignmentPadding)
+        XCTAssertEqual(alignedRect.height, size.height)
     }
 
     func testTopAlignedRect() throws {
@@ -64,7 +64,7 @@ class TextRendererTests: XCTestCase {
         let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .top))
 
         XCTAssertEqual(alignedRect.origin.y, rect.origin.y + (rect.height - alignedRect.height))
-        XCTAssertEqual(alignedRect.height, size.height + TextRenderer.verticalAlignmentPadding)
+        XCTAssertEqual(alignedRect.height, size.height)
     }
 
     func testCenterAlignedRect() throws {
@@ -74,8 +74,8 @@ class TextRendererTests: XCTestCase {
 
         let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .center))
 
-        XCTAssertEqual(alignedRect.origin.y, rect.origin.y + ((rect.height - alignedRect.height - TextRenderer.verticalAlignmentPadding) / 2))
-        XCTAssertEqual(alignedRect.height, size.height + TextRenderer.verticalAlignmentPadding)
+        XCTAssertEqual(alignedRect.origin.y, rect.origin.y + ((rect.height - alignedRect.height) / 2))
+        XCTAssertEqual(alignedRect.height, size.height)
     }
 
 }

--- a/Tests/SwiftFrameTests/TextRendererTests.swift
+++ b/Tests/SwiftFrameTests/TextRendererTests.swift
@@ -11,7 +11,7 @@ class TextRendererTests: XCTestCase {
         let maxSize = try renderer.maximumFontSizeThatFits(
             string: "Some testing string",
             font: NSFont.systemFont(ofSize: 200),
-            alignment: .center,
+            alignment: TextAlignment(horizontal: .center, vertical: .top),
             maxSize: 400,
             size: veryLargeSize)
 
@@ -25,7 +25,7 @@ class TextRendererTests: XCTestCase {
         XCTAssertThrowsError(try renderer.maximumFontSizeThatFits(
             string: "Some testing string",
             font: NSFont.systemFont(ofSize: 200),
-            alignment: .center,
+            alignment: TextAlignment(horizontal: .center, vertical: .top),
             maxSize: 400,
             size: smallSize))
     }
@@ -36,7 +36,13 @@ class TextRendererTests: XCTestCase {
         let rect = NSRect(x: 10, y: 10, width: 80, height: 80)
 
         let context = CGContext.with(size: size)
-        try renderer.render(text: "Some title", font: .systemFont(ofSize: 20), color: .red, alignment: .center, rect: rect, context: context)
+        try renderer.render(
+            text: "Some title",
+            font: .systemFont(ofSize: 20),
+            color: .red,
+            alignment: TextAlignment(horizontal: .center, vertical: .top),
+            rect: rect,
+            context: context)
     }
 
 }

--- a/Tests/SwiftFrameTests/TextRendererTests.swift
+++ b/Tests/SwiftFrameTests/TextRendererTests.swift
@@ -45,4 +45,37 @@ class TextRendererTests: XCTestCase {
             context: context)
     }
 
+    func testBottomAlignedRect() throws {
+        let renderer = TextRenderer()
+        let size = CGSize(width: 60, height: 60)
+        let rect = NSRect(x: 10, y: 10, width: 80, height: 80)
+
+        let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .bottom))
+
+        XCTAssertEqual(alignedRect.origin, rect.origin)
+        XCTAssertEqual(alignedRect.height, size.height + TextRenderer.verticalAlignmentPadding)
+    }
+
+    func testTopAlignedRect() throws {
+        let renderer = TextRenderer()
+        let size = CGSize(width: 60, height: 60)
+        let rect = NSRect(x: 10, y: 10, width: 80, height: 80)
+
+        let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .top))
+
+        XCTAssertEqual(alignedRect.origin.y, rect.origin.y + (rect.height - alignedRect.height))
+        XCTAssertEqual(alignedRect.height, size.height + TextRenderer.verticalAlignmentPadding)
+    }
+
+    func testCenterAlignedRect() throws {
+        let renderer = TextRenderer()
+        let size = CGSize(width: 60, height: 60)
+        let rect = NSRect(x: 10, y: 10, width: 80, height: 80)
+
+        let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .center))
+
+        XCTAssertEqual(alignedRect.origin.y, rect.origin.y + ((rect.height - alignedRect.height - TextRenderer.verticalAlignmentPadding) / 2))
+        XCTAssertEqual(alignedRect.height, size.height + TextRenderer.verticalAlignmentPadding)
+    }
+
 }

--- a/Tests/SwiftFrameTests/TextRendererTests.swift
+++ b/Tests/SwiftFrameTests/TextRendererTests.swift
@@ -15,7 +15,7 @@ class TextRendererTests: XCTestCase {
             maxSize: 400,
             size: veryLargeSize)
 
-        XCTAssertEqual(maxSize, 400 - TextRenderer.pointSizeTolerance)
+        XCTAssertEqual(maxSize, 400)
     }
 
     func testBoxTooSmall() {

--- a/Tests/SwiftFrameTests/Utility/TextDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/TextDataFixtures.swift
@@ -6,7 +6,7 @@ extension TextData {
 
     static let goodData = TextData(
         titleIdentifier: "someId",
-        textAlignment: .center,
+        textAlignment: TextAlignment(horizontal: .center, vertical: .top),
         maxFontSizeOverride: nil,
         fontOverride: nil,
         textColorOverrideString: nil,
@@ -17,7 +17,7 @@ extension TextData {
 
     static let invalidData = TextData(
         titleIdentifier: "someId",
-        textAlignment: .center,
+        textAlignment: TextAlignment(horizontal: .center, vertical: .top),
         maxFontSizeOverride: nil,
         fontOverride: nil,
         textColorOverrideString: nil,
@@ -28,7 +28,7 @@ extension TextData {
 
     static let invertedData = TextData(
         titleIdentifier: "someId",
-        textAlignment: .center,
+        textAlignment: TextAlignment(horizontal: .center, vertical: .top),
         maxFontSizeOverride: nil,
         fontOverride: nil,
         textColorOverrideString: nil,

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e
 
 SCRIPTPATH="$(dirname "$0")"
 
-swift build -c release --package-path "$SCRIPTPATH"
+swift build -c release --package-path "$SCRIPTPATH" -v
 cp -f "$SCRIPTPATH/.build/release/SwiftFrame" "/usr/local/bin/swiftframe"
 rm -r "$SCRIPTPATH/.build/release"
 


### PR DESCRIPTION
Main changes:
- `TextAlignment` has been refactored to a `struct` which differentiates between vertical and horizontal alignment
- the `alignment` key in config files therefore now has to be specified as an object with two subkeys (`horizontal` and `vertical`)
- `TextRenderer` now calculates a smaller frame to render text in, which is offset within the specified text bounds according to the used alignment mode
- `TextRenderer` now uses `CTFramesetterSuggestFrameSizeWithConstraints` to calculate text sizes, which makes calculation more robust and we can stop relying on subtracting a tiny bit of the calculated font size

Other changes include:
- richer error output when using the verbose flag
- empty strings will not throw an error anymore during processing but instead just print a warning during the rendering step and continue without attempting to render