### PR TITLE
Support for slice size override

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ To use SwiftFrame, you need to pass it a configuration file (which is a plain JS
   * `outputSuffix`: a suffix to apply to the output files in addition to the locale identifier and index
   * `screenshots`: a folder path containing a subfolder for each locale, which in turn contains all the screenshots for that device
   * `templateFile`: an image file that will be rendered above the screenshots to overlay device frames (e.g. see `Example/Template Files/iPhone X/TemplateFile.png`) **Note:** places where screenshots should go need to be transparent
+  * `sliceSizeOverride`: **optional** A custom slice size override in cases where you want to use different size screenshots (for example iPhone X screenshots with a iPhone 8 template file)
+    * `width`: The width of the custom slice size
+    * `height`: The height of the custom slice size 
   * `gapWidth`: **optional (default: 0)** a gap width in pixels that will be skipped after every screenshot that is sliced from the template file
   * `screenshotData`: an array containing further information about screenshot coordinates
     * `screenshotName`: the file name (just name, not path) to the screenshot file to render
     * `zIndex`: **optional**, use this to avoid wrong rendering order if two screenshots need to overlap each other for example
     * `bottomLeft`, `bottomRight`, `topLeft` and `topRight`: the corners of the screenshot to render. Note that screenshots can be rotated in 3D, so the corners of the resulting don't have to form 90 degree angles
       * `x`: The x coordinate of the corner point, relative to the left edge
-      * `y`: the y coordinate of the corner point, relative to the top or bottom edge, depending on `coordinatesOriginIsTopLeft`
+      * `y`: the y coordinate of the corner point, relative to the top or bottom edge
   * `textData`: an array containing further information about text titles coordinates and its layout
     * `titleIdentifer`: the key that SwiftFrame should look for in the `.strings` file for a certain title
     * `textColorOverride`: **optional**, a color in Hex format to use specifically for this title
@@ -47,7 +50,7 @@ To use SwiftFrame, you need to pass it a configuration file (which is a plain JS
     * `groupIdentifier`: **optional**, an identifier for a text group (see below)
     * `topLeft` and `bottomRight`: the bounding coordinate points of the text (as of right now, it's not possible to have rotated text)
       * `x`: The x coordinate of the corner point, relative to the left edge
-      * `y`: the y coordinate of the corner point, relative to the top or bottom edge, depending on `coordinatesOriginIsTopLeft` 
+      * `y`: the y coordinate of the corner point, relative to the top or bottom edge
 * `textGroups`: **optional**, an array of text groups which you can use to force multiple titles to use the same font size
   * `identifier`: the identifier of the text group
   * `maxFontSize`: the maximum font point size titles with this group ID should be using (overrides the global `maxFontSize`)

--- a/Sources/SwiftFrame/main.swift
+++ b/Sources/SwiftFrame/main.swift
@@ -9,7 +9,7 @@ struct SwiftFrame: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "swiftframe",
         abstract: "CLI application for speedy screenshot framing",
-        version: "3.0.0",
+        version: "3.1.0",
         helpNames: .shortAndLong)
 
     @Argument(help: "Read configuration values from the specified file", completion: .list(["config", "yml", "yaml"]))

--- a/Sources/SwiftFrameCore/Config/DeviceData.swift
+++ b/Sources/SwiftFrameCore/Config/DeviceData.swift
@@ -10,6 +10,7 @@ public struct DeviceData: Decodable, ConfigValidatable {
     let outputSuffix: String
     let templateImagePath: FileURL
     private let screenshotsPath: FileURL
+    let sliceSizeOverride: DecodableSize?
 
     @DecodableDefault.IntZero var gapWidth: Int
 
@@ -24,6 +25,7 @@ public struct DeviceData: Decodable, ConfigValidatable {
         case outputSuffix
         case screenshotsPath = "screenshots"
         case templateImagePath = "templateFile"
+        case sliceSizeOverride
         case screenshotData
         case textData
         case gapWidth
@@ -35,6 +37,7 @@ public struct DeviceData: Decodable, ConfigValidatable {
         outputSuffix: String,
         templateImagePath: FileURL,
         screenshotsPath: FileURL,
+        sliceSizeOverride: DecodableSize? = nil,
         screenshotsGroupedByLocale: [String: [String: URL]]? = nil,
         templateImage: NSBitmapImageRep? = nil,
         screenshotData: [ScreenshotData] = [ScreenshotData](),
@@ -44,6 +47,7 @@ public struct DeviceData: Decodable, ConfigValidatable {
         self.outputSuffix = outputSuffix
         self.templateImagePath = templateImagePath
         self.screenshotsPath = screenshotsPath
+        self.sliceSizeOverride = sliceSizeOverride
         self.screenshotsGroupedByLocale = screenshotsGroupedByLocale
         self.templateImage = templateImage
         self.screenshotData = screenshotData
@@ -78,6 +82,7 @@ public struct DeviceData: Decodable, ConfigValidatable {
             outputSuffix: outputSuffix,
             templateImagePath: templateImagePath,
             screenshotsPath: screenshotsPath,
+            sliceSizeOverride: sliceSizeOverride,
             screenshotsGroupedByLocale: parsedScreenshots,
             templateImage: rep,
             screenshotData: processedScreenshotData,
@@ -108,7 +113,7 @@ public struct DeviceData: Decodable, ConfigValidatable {
 
         // Now that we know all screenshots have the same resolution, we can validate that template image is multiple in width
         // plus specified gap width in between
-        if let screenshotSize = NSBitmapImageRep.ky_loadFromURL(screenshotsGroupedByLocale.first?.value.first?.value)?.ky_nativeSize {
+        if let screenshotSize = sliceSizeOverride?.cgSize ?? NSBitmapImageRep.ky_loadFromURL(screenshotsGroupedByLocale.first?.value.first?.value)?.ky_nativeSize {
             guard let templateImageSize = templateImage?.ky_nativeSize else {
                 throw NSError(description: "Template image for output suffix \"\(outputSuffix)\" could not be loaded for validation")
             }

--- a/Sources/SwiftFrameCore/Helper Types/DecodableSize.swift
+++ b/Sources/SwiftFrameCore/Helper Types/DecodableSize.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Wrapper struct used to work around weird decoding behaviour of `CGSize`
+struct DecodableSize: Codable {
+
+    let width: CGFloat
+    let height: CGFloat
+
+    var cgSize: CGSize {
+        CGSize(width: width, height: height)
+    }
+
+}

--- a/Sources/SwiftFrameCore/Workers/ConfigProcessor.swift
+++ b/Sources/SwiftFrameCore/Workers/ConfigProcessor.swift
@@ -83,7 +83,7 @@ public class ConfigProcessor {
                 throw NSError(description: "No template image found")
             }
 
-            guard let sliceSize = NSBitmapImageRep.ky_loadFromURL(imageDict.first?.value)?.ky_nativeSize else {
+            guard let sliceSize = deviceData.sliceSizeOverride?.cgSize ?? NSBitmapImageRep.ky_loadFromURL(imageDict.first?.value)?.ky_nativeSize else {
                 throw NSError(description: "No screenshots supplied, so it's impossible to slice into the correct size")
             }
 

--- a/Tests/SwiftFrameTests/Config Tests/DeviceDataTests.swift
+++ b/Tests/SwiftFrameTests/Config Tests/DeviceDataTests.swift
@@ -26,4 +26,14 @@ class DeviceDataTests: BaseTest {
         XCTAssertThrowsError(try data.validate())
     }
 
+    func testMismatchingDeviceSizeData() throws {
+        let data = try DeviceData.mismatchingDeviceSizeData.makeProcessedData(localesRegex: nil)
+        XCTAssertNoThrow(try data.validate())
+    }
+
+    func testFaultyMismatchingDeviceSizeData() throws {
+        let data = try DeviceData.faultyMismatchingDeviceSizeData.makeProcessedData(localesRegex: nil)
+        XCTAssertThrowsError(try data.validate())
+    }
+
 }

--- a/Tests/SwiftFrameTests/Utility/DeviceDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/DeviceDataFixtures.swift
@@ -25,4 +25,21 @@ extension DeviceData {
         screenshotData: [.goodData],
         textData: [.invalidData])
 
+    static let mismatchingDeviceSizeData = DeviceData(
+        outputSuffix: "iPhone X",
+        templateImagePath: FileURL(path: "testing/templatefile-debug_device1.png"),
+        screenshotsPath: FileURL(path: "testing/screenshots/"),
+        sliceSizeOverride: DecodableSize(width: 50, height: 100),
+        screenshotData: [.goodData],
+        textData: [.goodData])
+
+    static let faultyMismatchingDeviceSizeData = DeviceData(
+        outputSuffix: "iPhone X",
+        templateImagePath: FileURL(path: "testing/templatefile-debug_device1.png"),
+        screenshotsPath: FileURL(path: "testing/screenshots/"),
+        sliceSizeOverride: DecodableSize(width: 50, height: 100),
+        screenshotData: [.goodData],
+        textData: [.goodData],
+        gapWidth: 2)
+
 }


### PR DESCRIPTION
This adds the ability to specify a slice size override for cases where you might want to use different sized screenshots in a template file (for example iPhone X screenshots in combination with an iPhone 8 template file)

Closes #19 