### PR TITLE
Typos and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ The format of the configuration file is specified as following (indent levels re
 
 -   `stringsPath`: a path to a folder with `.strings` files, prefixed with the corresponding locale (e.g. `en.strings`)
 -   `maxFontSize`: the maximum font point size to use. SwiftFrame will be always try to render the text at the largest point size that fits within the bounding rectangle. If the determined point size is larger than `maxFontSize`, the latter will be used
--   `outputPaths`: an array of paths to where SwiftFrame should output the finished screenshots. This is an array in case you want to render the files into multiple directories at the same time. (Note: screenshots will be placed into subfolders organised by locale within these paths)
+-   `outputPaths`: an array of paths to where SwiftFrame should output the finished screenshots. This is an array in case you want to render the files into multiple directories at the same time. (Note: screenshots will be placed into subfolders organized by locale within these paths)
 -   `fontFile`: a path to a font file
 -   `format`: the output format of the screenshots, can be `png`, `jpeg` or `jpg`
 -   `textColor`: a RGB color in Hex format (e.g. `#FFF`) to use for titles
 -   `outputWholeImage`: **optional (default: false)** a boolean telling the application whether or not to also output the whole image instead of just the sliced up screenshots
 -   `clearDirectories`: **optional (default: true)** a boolean telling the application whether or not to clear the specified output directories before writing new files to it. This prevents random screenshots from being used in case you update your template file to include one less screenshot for example
--   `locales`: **optional** a regular expression that can be used to exlude (or include) certain locales during rendering. To only include `fr` and `de` locale for example, use `"fr|de"`. To exclude `ru` and `fr`, use something like `"^(?!ru|fr$)\\w*$"`
+-   `locales`: **optional** a regular expression that can be used to exclude (or include) certain locales during rendering. To only include `fr` and `de` locale for example, use `"fr|de"`. To exclude `ru` and `fr`, use something like `"^(?!ru|fr$)\\w*$"`
 -   `deviceData`: an array containing device specific data about screenshot and text coordinates (this way you can frame screenshots for more than one device per config file)
     -   `outputSuffixes`: an array of suffixes to apply to the output files in addition to the locale identifier and index. Multiple suffixes can be used to render the same screenshots for different target devices (for example 2nd and 3rd 12.9 inch iPad Pro)
     -   `screenshots`: a folder path containing a subfolder for each locale, which in turn contains all the screenshots for that device
@@ -76,9 +76,9 @@ The format of the configuration file is specified as following (indent levels re
             -   `x`: The x coordinate of the corner point, relative to the left edge
             -   `y`: the y coordinate of the corner point, relative to the top or bottom edge
     -   `textData`: an array containing further information about text titles coordinates and its layout
-        -   `titleIdentifer`: the key that SwiftFrame should look for in the `.strings` file for a certain title
-        -   `textColorOverride`: **optional**, a color in Hex format to use specifically for this title
-        -   `textAlignment`: information about text alignment
+        -   `identifier`: the key that SwiftFrame should look for in the `.strings` file for a certain title
+        -   `colorOverride`: **optional**, a color in Hex format to use specifically for this title
+        -   `alignment`: information about text alignment
             -   `horizontal`: the horizontal text alignment in CSS style (`left`, `right`, `center`, `justify` or `natural`)
             -   `vertical`: the vertical text alignment in (`top`, `center`, `bottom`)
         -   `customFontPath`: **optional**, a path to a font file to use specifically for this title

--- a/Sources/SwiftFrameCore/Config/ConfigData.swift
+++ b/Sources/SwiftFrameCore/Config/ConfigData.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AppKit
 
-protocol ConfigValidatable {
+protocol ConfigValidateable {
     func validate() throws
     func printSummary(insetByTabs tabs: Int)
 }
@@ -9,7 +9,7 @@ protocol ConfigValidatable {
 /// First key is locale, second is regular key in string file
 typealias LocalizedStringFiles = [String: [String: String]]
 
-struct ConfigData: Decodable, ConfigValidatable {
+struct ConfigData: Decodable, ConfigValidateable {
 
     // MARK: - Properties
 
@@ -89,7 +89,7 @@ struct ConfigData: Decodable, ConfigValidatable {
         titles = Dictionary(uniqueKeysWithValues: zip(textFiles.map({ $0.fileName }), strings))
     }
 
-    // MARK: - ConfigValidatable
+    // MARK: - ConfigValidateable
 
     public func validate() throws {
         guard !deviceData.isEmpty else {

--- a/Sources/SwiftFrameCore/Config/DeviceData.swift
+++ b/Sources/SwiftFrameCore/Config/DeviceData.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Foundation
 
-public struct DeviceData: Decodable, ConfigValidatable {
+public struct DeviceData: Decodable, ConfigValidateable {
 
     // MARK: - Properties
 
@@ -94,7 +94,7 @@ public struct DeviceData: Decodable, ConfigValidatable {
             gapWidth: gapWidth)
     }
 
-    // MARK: - ConfigValidatable
+    // MARK: - ConfigValidateable
 
     func validate() throws {
         guard !screenshotsGroupedByLocale.isEmpty else {

--- a/Sources/SwiftFrameCore/Config/ScreenshotData.swift
+++ b/Sources/SwiftFrameCore/Config/ScreenshotData.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ScreenshotData: Decodable, ConfigValidatable, Equatable {
+public struct ScreenshotData: Decodable, ConfigValidateable, Equatable {
 
     // MARK: - Properties
 
@@ -35,7 +35,7 @@ public struct ScreenshotData: Decodable, ConfigValidatable, Equatable {
             zIndex: zIndex)
     }
 
-    // MARK: - ConfigValidatable
+    // MARK: - ConfigValidateable
 
     func validate() throws {}
 

--- a/Sources/SwiftFrameCore/Config/TextData.swift
+++ b/Sources/SwiftFrameCore/Config/TextData.swift
@@ -3,7 +3,7 @@ import Foundation
 
 typealias AssociatedString = (string: String, data: TextData)
 
-struct TextData: Decodable, ConfigValidatable {
+struct TextData: Decodable, ConfigValidateable {
 
     // MARK: - Properties
 
@@ -80,7 +80,7 @@ struct TextData: Decodable, ConfigValidatable {
             textColorOverride: colorOverride)
     }
 
-    // MARK: - ConfigValidatable
+    // MARK: - ConfigValidateable
 
     func validate() throws {
         guard (topLeft.x < bottomRight.x) && (topLeft.y > bottomRight.y) else {

--- a/Sources/SwiftFrameCore/Config/TextGroup.swift
+++ b/Sources/SwiftFrameCore/Config/TextGroup.swift
@@ -3,7 +3,7 @@ import Foundation
 
 private let kNumTitleLines = 3
 
-public struct TextGroup: Decodable, ConfigValidatable, Hashable {
+public struct TextGroup: Decodable, ConfigValidateable, Hashable {
 
     // MARK: - Properties
 
@@ -17,7 +17,7 @@ public struct TextGroup: Decodable, ConfigValidatable, Hashable {
         case maxFontSize
     }
 
-    // MARK: - ConfigValidatable
+    // MARK: - ConfigValidateable
 
     func validate() throws {}
 

--- a/Sources/SwiftFrameCore/Helper Types/DecodableSize.swift
+++ b/Sources/SwiftFrameCore/Helper Types/DecodableSize.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Wrapper struct used to work around weird decoding behaviour of `CGSize`
+/// Wrapper struct used to work around weird decoding behavior of `CGSize`
 struct DecodableSize: Codable {
 
     let width: CGFloat

--- a/Sources/SwiftFrameCore/Workers/AttributedStringCache.swift
+++ b/Sources/SwiftFrameCore/Workers/AttributedStringCache.swift
@@ -19,7 +19,7 @@ final class AttributedStringCache: NSObject {
     // MARK: - Reading/Writing to cache
 
     func attributedString(forTitleIdentifier titleIdentifier: String, locale: String, deviceIdentifier: String) throws -> NSAttributedString {
-        let identifier = makeCacheIdentifier(titleIdentifer: titleIdentifier, locale: locale, deviceIdentifier: deviceIdentifier)
+        let identifier = makeCacheIdentifier(titleIdentifier: titleIdentifier, locale: locale, deviceIdentifier: deviceIdentifier)
         guard let value = cache[identifier] else {
             throw NSError(description: "Could not find value for key \"\(identifier)\" in attributed string cache")
         }
@@ -76,7 +76,7 @@ final class AttributedStringCache: NSObject {
         let adaptedFont = font.ky_toFont(ofSize: fontSize)
         let attributedString = try TextRenderer.makeAttributedString(for: title, font: adaptedFont, color: color, alignment: textData.textAlignment)
 
-        let identifier = makeCacheIdentifier(titleIdentifer: textData.titleIdentifier, locale: locale, deviceIdentifier: deviceIdentifier)
+        let identifier = makeCacheIdentifier(titleIdentifier: textData.titleIdentifier, locale: locale, deviceIdentifier: deviceIdentifier)
         #if DEBUG
         print("Caching attributed string with key:", identifier, "point size:", fontSize)
         #endif
@@ -86,8 +86,8 @@ final class AttributedStringCache: NSObject {
         cache[identifier] = attributedString
     }
 
-    private func makeCacheIdentifier(titleIdentifer: String, locale: String, deviceIdentifier: String) -> String {
-        [locale, titleIdentifer, deviceIdentifier].joined(separator: "_")
+    private func makeCacheIdentifier(titleIdentifier: String, locale: String, deviceIdentifier: String) -> String {
+        [locale, titleIdentifier, deviceIdentifier].joined(separator: "_")
     }
 
 }

--- a/Sources/SwiftFrameCore/Workers/CommandLineFormatter.swift
+++ b/Sources/SwiftFrameCore/Workers/CommandLineFormatter.swift
@@ -10,7 +10,7 @@ public final class CommandLineFormatter {
         case yellow = 33
         case `default` = 39
 
-        var escapeSquence: String {
+        var escapeSequence: String {
             "\u{001B}[0;\(rawValue)m"
         }
     }
@@ -38,7 +38,7 @@ public final class CommandLineFormatter {
         if ConfigProcessor.noColorOutput {
             return message
         } else {
-            return [color.escapeSquence, message, Color.default.escapeSquence].joined()
+            return [color.escapeSequence, message, Color.default.escapeSequence].joined()
         }
     }
 

--- a/Sources/SwiftFrameCore/Workers/ConfigProcessor.swift
+++ b/Sources/SwiftFrameCore/Workers/ConfigProcessor.swift
@@ -113,7 +113,8 @@ public class ConfigProcessor: VerbosePrintable {
                 outputWholeImage: data.outputWholeImage,
                 locale: locale,
                 suffixes: deviceData.outputSuffixes,
-                format: data.outputFormat)
+                format: data.outputFormat
+            )
 
             deviceData.outputSuffixes.forEach { suffix in
                 print("Finished \(locale)-\(suffix)")

--- a/Tests/SwiftFrameTests/Utility/ConfigDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/ConfigDataFixtures.swift
@@ -14,7 +14,8 @@ extension ConfigData {
         outputFormat: .png,
         clearDirectories: true,
         outputWholeImage: true,
-        deviceData: [.goodData])
+        deviceData: [.goodData]
+    )
 
     static let skippedLocaleData = ConfigData(
         textGroups: [],
@@ -27,7 +28,8 @@ extension ConfigData {
         clearDirectories: true,
         outputWholeImage: true,
         deviceData: [.goodData],
-        localesRegex: "^(?!en|fr$)\\w*$")
+        localesRegex: "^(?!en|fr$)\\w*$"
+    )
 
     static let englishOnlyData = ConfigData(
         textGroups: [],
@@ -40,7 +42,8 @@ extension ConfigData {
         clearDirectories: true,
         outputWholeImage: true,
         deviceData: [.goodData],
-        localesRegex: "en")
+        localesRegex: "en"
+    )
 
     static let invalidData = ConfigData(
         textGroups: [],
@@ -52,6 +55,7 @@ extension ConfigData {
         outputFormat: .png,
         clearDirectories: true,
         outputWholeImage: true,
-        deviceData: [.invalidData])
+        deviceData: [.invalidData]
+    )
 
 }

--- a/Tests/SwiftFrameTests/Utility/DeviceDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/DeviceDataFixtures.swift
@@ -8,7 +8,8 @@ extension DeviceData {
         templateImagePath: FileURL(path: "testing/templatefile-debug_device1.png"),
         screenshotsPath: FileURL(path: "testing/screenshots/"),
         screenshotData: [.goodData],
-        textData: [.goodData])
+        textData: [.goodData]
+    )
 
     static let gapData = DeviceData(
         outputSuffixes: ["iPhone X"],
@@ -16,14 +17,16 @@ extension DeviceData {
         screenshotsPath: FileURL(path: "testing/screenshots/"),
         screenshotData: [.goodData],
         textData: [.goodData],
-        gapWidth: 16)
+        gapWidth: 16
+    )
 
     static let invalidData = DeviceData(
         outputSuffixes: ["iPhone X"],
         templateImagePath: FileURL(path: "testing/templatefile-debug_device1.png"),
         screenshotsPath: FileURL(path: "testing/screenshots/"),
         screenshotData: [.goodData],
-        textData: [.invalidData])
+        textData: [.invalidData]
+    )
 
     static let mismatchingDeviceSizeData = DeviceData(
         outputSuffixes: ["iPhone X"],
@@ -31,7 +34,8 @@ extension DeviceData {
         screenshotsPath: FileURL(path: "testing/screenshots/"),
         sliceSizeOverride: DecodableSize(width: 50, height: 100),
         screenshotData: [.goodData],
-        textData: [.goodData])
+        textData: [.goodData]
+    )
 
     static let faultyMismatchingDeviceSizeData = DeviceData(
         outputSuffixes: ["iPhone X"],
@@ -40,6 +44,7 @@ extension DeviceData {
         sliceSizeOverride: DecodableSize(width: 50, height: 100),
         screenshotData: [.goodData],
         textData: [.goodData],
-        gapWidth: 2)
+        gapWidth: 2
+    )
 
 }

--- a/Tests/SwiftFrameTests/Utility/ScreenshotDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/ScreenshotDataFixtures.swift
@@ -9,6 +9,7 @@ extension ScreenshotData {
         bottomRight: Point(x: 40, y: 10),
         topLeft: Point(x: 10, y: 200),
         topRight: Point(x: 40, y: 200),
-        zIndex: 1)
+        zIndex: 1
+    )
 
 }


### PR DESCRIPTION
This PR fixes a bunch of typos and some wrong keys in the `README` file. No semantic changes have been made so this should be a quick one