### PR TITLE
Scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ $ mint install kayak/SwiftFrame
 
 However, if you'd like you can also build SwiftFrame from source. To do this clone the repository and run the `install.sh` script. This will compile a binary and install it into `usr/local/bin/swiftframe`.
 
-- clone the repository (e.g. `git clone https://github.com/kayak/SwiftFrame`)
-- change into the directory: `cd SwiftFrame`
-- run the install script: `sh install.sh`
+-   clone the repository (e.g. `git clone https://github.com/kayak/SwiftFrame`)
+-   change into the directory: `cd SwiftFrame`
+-   run the install script: `sh install.sh`
 
 ## Usage
 
@@ -52,43 +52,43 @@ You can also use the `--help` flag to print SwiftFrame's documentation out
 
 The format of the configuration file is specified as following (indent levels represent nesting levels within the file):
 
-- `stringsPath`: a path to a folder with `.strings` files, prefixed with the corresponding locale (e.g. `en.strings`)
-- `maxFontSize`: the maximum font point size to use. SwiftFrame will be always try to render the text at the largest point size that fits within the bounding rectangle. If the determined point size is larger than `maxFontSize`, the latter will be used
-- `outputPaths`: an array of paths to where SwiftFrame should output the finished screenshots. This is an array in case you want to render the files into multiple directories at the same time. (Note: screenshots will be placed into subfolders organised by locale within these paths)
-- `fontFile`: a path to a font file
-- `format`: the output format of the screenshots, can be `png`, `jpeg` or `jpg`
-- `textColor`: a RGB color in Hex format (e.g. `#FFF`) to use for titles
-- `outputWholeImage`: **optional (default: false)** a boolean telling the application whether or not to also output the whole image instead of just the sliced up screenshots
-- `clearDirectories`: **optional (default: true)** a boolean telling the application whether or not to clear the specified output directories before writing new files to it. This prevents random screenshots from being used in case you update your template file to include one less screenshot for example
-- `locales`: **optional** a regular expression that can be used to exlude (or include) certain locales during rendering. To only include `fr` and `de` locale for example, use `"fr|de"`. To exclude `ru` and `fr`, use something like `"^(?!ru|fr$)\\w*$"`
-- `deviceData`: an array containing device specific data about screenshot and text coordinates (this way you can frame screenshots for more than one device per config file)
-  - `outputSuffixes`: an array of suffixes to apply to the output files in addition to the locale identifier and index. Multiple suffixes can be used to render the same screenshots for different target devices (for example 2nd and 3rd 12.9 inch iPad Pro)
-  - `screenshots`: a folder path containing a subfolder for each locale, which in turn contains all the screenshots for that device
-  - `templateFile`: an image file that will be rendered above the screenshots to overlay device frames (e.g. see `Example/Template Files/iPhone X/TemplateFile.png`) **Note:** places where screenshots should go need to be transparent
-  - `sliceSizeOverride`: **optional** A custom slice size override in cases where you want to use different size screenshots (for example iPhone X screenshots with a iPhone 8 template file)
-    - `width`: The width of the custom slice size
-    - `height`: The height of the custom slice size
-  - `gapWidth`: **optional (default: 0)** a gap width in pixels that will be skipped after every screenshot that is sliced from the template file
-  - `screenshotData`: an array containing further information about screenshot coordinates
-    - `screenshotName`: the file name (just name, not path) to the screenshot file to render
-    - `zIndex`: **optional**, use this to avoid wrong rendering order if two screenshots need to overlap each other for example
-    - `bottomLeft`, `bottomRight`, `topLeft` and `topRight`: the corners of the screenshot to render. Note that screenshots can be rotated in 3D, so the corners of the resulting don't have to form 90 degree angles
-      - `x`: The x coordinate of the corner point, relative to the left edge
-      - `y`: the y coordinate of the corner point, relative to the top or bottom edge
-  - `textData`: an array containing further information about text titles coordinates and its layout
-    - `titleIdentifer`: the key that SwiftFrame should look for in the `.strings` file for a certain title
-    - `textColorOverride`: **optional**, a color in Hex format to use specifically for this title
-    - `textAlignment`: information about text alignment
-      - `horizontal`: the horizontal text alignment in CSS style (`left`, `right`, `center`, `justify` or `natural`)
-      - `vertical`: the vertical text alignment in (`top`, `center`, `bottom`)
-    - `customFontPath`: **optional**, a path to a font file to use specifically for this title
-    - `groupIdentifier`: **optional**, an identifier for a text group (see below)
-    - `topLeft` and `bottomRight`: the bounding coordinate points of the text (as of right now, it's not possible to have rotated text)
-      - `x`: The x coordinate of the corner point, relative to the left edge
-      - `y`: the y coordinate of the corner point, relative to the top or bottom edge
-- `textGroups`: **optional**, an array of text groups which you can use to force multiple titles to use the same font size
-  - `identifier`: the identifier of the text group
-  - `maxFontSize`: the maximum font point size titles with this group ID should be using (overrides the global `maxFontSize`)
+-   `stringsPath`: a path to a folder with `.strings` files, prefixed with the corresponding locale (e.g. `en.strings`)
+-   `maxFontSize`: the maximum font point size to use. SwiftFrame will be always try to render the text at the largest point size that fits within the bounding rectangle. If the determined point size is larger than `maxFontSize`, the latter will be used
+-   `outputPaths`: an array of paths to where SwiftFrame should output the finished screenshots. This is an array in case you want to render the files into multiple directories at the same time. (Note: screenshots will be placed into subfolders organised by locale within these paths)
+-   `fontFile`: a path to a font file
+-   `format`: the output format of the screenshots, can be `png`, `jpeg` or `jpg`
+-   `textColor`: a RGB color in Hex format (e.g. `#FFF`) to use for titles
+-   `outputWholeImage`: **optional (default: false)** a boolean telling the application whether or not to also output the whole image instead of just the sliced up screenshots
+-   `clearDirectories`: **optional (default: true)** a boolean telling the application whether or not to clear the specified output directories before writing new files to it. This prevents random screenshots from being used in case you update your template file to include one less screenshot for example
+-   `locales`: **optional** a regular expression that can be used to exlude (or include) certain locales during rendering. To only include `fr` and `de` locale for example, use `"fr|de"`. To exclude `ru` and `fr`, use something like `"^(?!ru|fr$)\\w*$"`
+-   `deviceData`: an array containing device specific data about screenshot and text coordinates (this way you can frame screenshots for more than one device per config file)
+    -   `outputSuffixes`: an array of suffixes to apply to the output files in addition to the locale identifier and index. Multiple suffixes can be used to render the same screenshots for different target devices (for example 2nd and 3rd 12.9 inch iPad Pro)
+    -   `screenshots`: a folder path containing a subfolder for each locale, which in turn contains all the screenshots for that device
+    -   `templateFile`: an image file that will be rendered above the screenshots to overlay device frames (e.g. see `Example/Template Files/iPhone X/TemplateFile.png`) **Note:** places where screenshots should go need to be transparent
+    -   `sliceSizeOverride`: **optional** A custom slice size override in cases where you want to use different size screenshots (for example iPhone X screenshots with a iPhone 8 template file)
+        -   `width`: The width of the custom slice size
+        -   `height`: The height of the custom slice size
+    -   `gapWidth`: **optional (default: 0)** a gap width in pixels that will be skipped after every screenshot that is sliced from the template file
+    -   `screenshotData`: an array containing further information about screenshot coordinates
+        -   `screenshotName`: the file name (just name, not path) to the screenshot file to render
+        -   `zIndex`: **optional**, use this to avoid wrong rendering order if two screenshots need to overlap each other for example
+        -   `bottomLeft`, `bottomRight`, `topLeft` and `topRight`: the corners of the screenshot to render. Note that screenshots can be rotated in 3D, so the corners of the resulting don't have to form 90 degree angles
+            -   `x`: The x coordinate of the corner point, relative to the left edge
+            -   `y`: the y coordinate of the corner point, relative to the top or bottom edge
+    -   `textData`: an array containing further information about text titles coordinates and its layout
+        -   `titleIdentifer`: the key that SwiftFrame should look for in the `.strings` file for a certain title
+        -   `textColorOverride`: **optional**, a color in Hex format to use specifically for this title
+        -   `textAlignment`: information about text alignment
+            -   `horizontal`: the horizontal text alignment in CSS style (`left`, `right`, `center`, `justify` or `natural`)
+            -   `vertical`: the vertical text alignment in (`top`, `center`, `bottom`)
+        -   `customFontPath`: **optional**, a path to a font file to use specifically for this title
+        -   `groupIdentifier`: **optional**, an identifier for a text group (see below)
+        -   `topLeft` and `bottomRight`: the bounding coordinate points of the text (as of right now, it's not possible to have rotated text)
+            -   `x`: The x coordinate of the corner point, relative to the left edge
+            -   `y`: the y coordinate of the corner point, relative to the top or bottom edge
+-   `textGroups`: **optional**, an array of text groups which you can use to force multiple titles to use the same font size
+    -   `identifier`: the identifier of the text group
+    -   `maxFontSize`: the maximum font point size titles with this group ID should be using (overrides the global `maxFontSize`)
 
 ## Example
 
@@ -104,17 +104,25 @@ swiftframe scaffold "en" "de" --path path/of/your/desired/swiftframe/scaffold
 
 After the subcommand `scaffold` you specify all the locales that you want to create folders/files for. After that you need to specify the path where you want the scaffold to be created.
 
-There are also some options available:
+### Available Options
 
-- `--lowercased-directories` will create directories with lowercased names
-- `--verbose` will print some additional information, for example how many folders and files were created
-- `--no-helper-files` will cause SwiftFrame to not create sample files for each locale/device. Otherwise a sample `.strings` file and some `README.md` files will be written in the folders to help you get started
+#### --lowercased-directories
+
+This flag will create directories with lowercased names
+
+#### --no-helper-files
+
+With this flag SwiftFrame will not create sample files for each locale/device. Otherwise a sample `.strings` file and some `README.md` files will be written in the folders to help you get started
+
+#### --verbose
+
+Will print some additional information, for example how many folders and files were created
 
 ## Why not frameit?
 
 Fastlane's [frameit](https://github.com/fastlane/fastlane/tree/master/frameit) is an awesome tool but we have, unfortunately, found it to be too limitting for our own needs. At the time of writing this, the following reasons drove us towards implementing a stand-alone solution:
 
-- No 3D placement of screenshots or support for multiple titles/screenshot in one framed image
-- Long titles could not properly be forced onto more than one line in frameit. The font size just shrinks until the text fits onto a single line which usually produces small text and different font sizes for every screenshot.
-- Due to the multitude of brands and locales that we support, we had to offload frameit to our build server since running it locally and on demand turned out to be too slow.
-- The fact that frameit was built on top of imagemagick seemingly made it hard to easily address any of the above with a pull request.
+-   No 3D placement of screenshots or support for multiple titles/screenshot in one framed image
+-   Long titles could not properly be forced onto more than one line in frameit. The font size just shrinks until the text fits onto a single line which usually produces small text and different font sizes for every screenshot.
+-   Due to the multitude of brands and locales that we support, we had to offload frameit to our build server since running it locally and on demand turned out to be too slow.
+-   The fact that frameit was built on top of imagemagick seemingly made it hard to easily address any of the above with a pull request.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ $ mint install kayak/SwiftFrame
 
 However, if you'd like you can also build SwiftFrame from source. To do this clone the repository and run the `install.sh` script. This will compile a binary and install it into `usr/local/bin/swiftframe`.
 
--   clone the repository (e.g. `git clone https://github.com/kayak/SwiftFrame`)
--   change into the directory: `cd SwiftFrame`
--   run the install script: `sh install.sh`
+- clone the repository (e.g. `git clone https://github.com/kayak/SwiftFrame`)
+- change into the directory: `cd SwiftFrame`
+- run the install script: `sh install.sh`
 
 ## Usage
 
@@ -52,53 +52,69 @@ You can also use the `--help` flag to print SwiftFrame's documentation out
 
 The format of the configuration file is specified as following (indent levels represent nesting levels within the file):
 
--   `stringsPath`: a path to a folder with `.strings` files, prefixed with the corresponding locale (e.g. `en.strings`)
--   `maxFontSize`: the maximum font point size to use. SwiftFrame will be always try to render the text at the largest point size that fits within the bounding rectangle. If the determined point size is larger than `maxFontSize`, the latter will be used
--   `outputPaths`: an array of paths to where SwiftFrame should output the finished screenshots. This is an array in case you want to render the files into multiple directories at the same time. (Note: screenshots will be placed into subfolders organised by locale within these paths)
--   `fontFile`: a path to a font file
--   `format`: the output format of the screenshots, can be `png`, `jpeg` or `jpg`
--   `textColor`: a RGB color in Hex format (e.g. `#FFF`) to use for titles
--   `outputWholeImage`: **optional (default: false)** a boolean telling the application whether or not to also output the whole image instead of just the sliced up screenshots
--   `clearDirectories`: **optional (default: true)** a boolean telling the application whether or not to clear the specified output directories before writing new files to it. This prevents random screenshots from being used in case you update your template file to include one less screenshot for example
--   `locales`: **optional** a regular expression that can be used to exlude (or include) certain locales during rendering. To only include `fr` and `de` locale for example, use `"fr|de"`. To exclude `ru` and `fr`, use something like `"^(?!ru|fr$)\\w*$"`
--   `deviceData`: an array containing device specific data about screenshot and text coordinates (this way you can frame screenshots for more than one device per config file)
-    -   `outputSuffixes`: an array of suffixes to apply to the output files in addition to the locale identifier and index. Multiple suffixes can be used to render the same screenshots for different target devices (for example 2nd and 3rd 12.9 inch iPad Pro)
-    -   `screenshots`: a folder path containing a subfolder for each locale, which in turn contains all the screenshots for that device
-    -   `templateFile`: an image file that will be rendered above the screenshots to overlay device frames (e.g. see `Example/Template Files/iPhone X/TemplateFile.png`) **Note:** places where screenshots should go need to be transparent
-    -   `sliceSizeOverride`: **optional** A custom slice size override in cases where you want to use different size screenshots (for example iPhone X screenshots with a iPhone 8 template file)
-        -   `width`: The width of the custom slice size
-        -   `height`: The height of the custom slice size
-    -   `gapWidth`: **optional (default: 0)** a gap width in pixels that will be skipped after every screenshot that is sliced from the template file
-    -   `screenshotData`: an array containing further information about screenshot coordinates
-        -   `screenshotName`: the file name (just name, not path) to the screenshot file to render
-        -   `zIndex`: **optional**, use this to avoid wrong rendering order if two screenshots need to overlap each other for example
-        -   `bottomLeft`, `bottomRight`, `topLeft` and `topRight`: the corners of the screenshot to render. Note that screenshots can be rotated in 3D, so the corners of the resulting don't have to form 90 degree angles
-            -   `x`: The x coordinate of the corner point, relative to the left edge
-            -   `y`: the y coordinate of the corner point, relative to the top or bottom edge
-    -   `textData`: an array containing further information about text titles coordinates and its layout
-        -   `titleIdentifer`: the key that SwiftFrame should look for in the `.strings` file for a certain title
-        -   `textColorOverride`: **optional**, a color in Hex format to use specifically for this title
-        -   `textAlignment`: information about text alignment
-            -   `horizontal`: the horizontal text alignment in CSS style (`left`, `right`, `center`, `justify` or `natural`)
-            -   `vertical`: the vertical text alignment in (`top`, `center`, `bottom`)
-        -   `customFontPath`: **optional**, a path to a font file to use specifically for this title
-        -   `groupIdentifier`: **optional**, an identifier for a text group (see below)
-        -   `topLeft` and `bottomRight`: the bounding coordinate points of the text (as of right now, it's not possible to have rotated text)
-            -   `x`: The x coordinate of the corner point, relative to the left edge
-            -   `y`: the y coordinate of the corner point, relative to the top or bottom edge
--   `textGroups`: **optional**, an array of text groups which you can use to force multiple titles to use the same font size
-    -   `identifier`: the identifier of the text group
-    -   `maxFontSize`: the maximum font point size titles with this group ID should be using (overrides the global `maxFontSize`)
+- `stringsPath`: a path to a folder with `.strings` files, prefixed with the corresponding locale (e.g. `en.strings`)
+- `maxFontSize`: the maximum font point size to use. SwiftFrame will be always try to render the text at the largest point size that fits within the bounding rectangle. If the determined point size is larger than `maxFontSize`, the latter will be used
+- `outputPaths`: an array of paths to where SwiftFrame should output the finished screenshots. This is an array in case you want to render the files into multiple directories at the same time. (Note: screenshots will be placed into subfolders organised by locale within these paths)
+- `fontFile`: a path to a font file
+- `format`: the output format of the screenshots, can be `png`, `jpeg` or `jpg`
+- `textColor`: a RGB color in Hex format (e.g. `#FFF`) to use for titles
+- `outputWholeImage`: **optional (default: false)** a boolean telling the application whether or not to also output the whole image instead of just the sliced up screenshots
+- `clearDirectories`: **optional (default: true)** a boolean telling the application whether or not to clear the specified output directories before writing new files to it. This prevents random screenshots from being used in case you update your template file to include one less screenshot for example
+- `locales`: **optional** a regular expression that can be used to exlude (or include) certain locales during rendering. To only include `fr` and `de` locale for example, use `"fr|de"`. To exclude `ru` and `fr`, use something like `"^(?!ru|fr$)\\w*$"`
+- `deviceData`: an array containing device specific data about screenshot and text coordinates (this way you can frame screenshots for more than one device per config file)
+  - `outputSuffixes`: an array of suffixes to apply to the output files in addition to the locale identifier and index. Multiple suffixes can be used to render the same screenshots for different target devices (for example 2nd and 3rd 12.9 inch iPad Pro)
+  - `screenshots`: a folder path containing a subfolder for each locale, which in turn contains all the screenshots for that device
+  - `templateFile`: an image file that will be rendered above the screenshots to overlay device frames (e.g. see `Example/Template Files/iPhone X/TemplateFile.png`) **Note:** places where screenshots should go need to be transparent
+  - `sliceSizeOverride`: **optional** A custom slice size override in cases where you want to use different size screenshots (for example iPhone X screenshots with a iPhone 8 template file)
+    - `width`: The width of the custom slice size
+    - `height`: The height of the custom slice size
+  - `gapWidth`: **optional (default: 0)** a gap width in pixels that will be skipped after every screenshot that is sliced from the template file
+  - `screenshotData`: an array containing further information about screenshot coordinates
+    - `screenshotName`: the file name (just name, not path) to the screenshot file to render
+    - `zIndex`: **optional**, use this to avoid wrong rendering order if two screenshots need to overlap each other for example
+    - `bottomLeft`, `bottomRight`, `topLeft` and `topRight`: the corners of the screenshot to render. Note that screenshots can be rotated in 3D, so the corners of the resulting don't have to form 90 degree angles
+      - `x`: The x coordinate of the corner point, relative to the left edge
+      - `y`: the y coordinate of the corner point, relative to the top or bottom edge
+  - `textData`: an array containing further information about text titles coordinates and its layout
+    - `titleIdentifer`: the key that SwiftFrame should look for in the `.strings` file for a certain title
+    - `textColorOverride`: **optional**, a color in Hex format to use specifically for this title
+    - `textAlignment`: information about text alignment
+      - `horizontal`: the horizontal text alignment in CSS style (`left`, `right`, `center`, `justify` or `natural`)
+      - `vertical`: the vertical text alignment in (`top`, `center`, `bottom`)
+    - `customFontPath`: **optional**, a path to a font file to use specifically for this title
+    - `groupIdentifier`: **optional**, an identifier for a text group (see below)
+    - `topLeft` and `bottomRight`: the bounding coordinate points of the text (as of right now, it's not possible to have rotated text)
+      - `x`: The x coordinate of the corner point, relative to the left edge
+      - `y`: the y coordinate of the corner point, relative to the top or bottom edge
+- `textGroups`: **optional**, an array of text groups which you can use to force multiple titles to use the same font size
+  - `identifier`: the identifier of the text group
+  - `maxFontSize`: the maximum font point size titles with this group ID should be using (overrides the global `maxFontSize`)
 
 ## Example
 
 To run the example, either install the CLI (see above) and run `swiftframe Example/example.config --verbose` or directly via `swift run swiftframe Example/example.config --verbose`
 
+## Scaffolding
+
+SwiftFrame also provides a subcommand to quickly setup the folder structure needed to get started with SwiftFrame. To scaffold, use the following command:
+
+```
+swiftframe scaffold "en" "de" --path path/of/your/desired/swiftframe/scaffold
+```
+
+After the subcommand `scaffold` you specify all the locales that you want to create folders/files for. After that you need to specify the path where you want the scaffold to be created.
+
+There are also some options available:
+
+- `--lowercased-directories` will create directories with lowercased names
+- `--verbose` will print some additional information, for example how many folders and files were created
+- `--no-helper-files` will cause SwiftFrame to not create sample files for each locale/device. Otherwise a sample `.strings` file and some `README.md` files will be written in the folders to help you get started
+
 ## Why not frameit?
 
 Fastlane's [frameit](https://github.com/fastlane/fastlane/tree/master/frameit) is an awesome tool but we have, unfortunately, found it to be too limitting for our own needs. At the time of writing this, the following reasons drove us towards implementing a stand-alone solution:
 
--   No 3D placement of screenshots or support for multiple titles/screenshot in one framed image
--   Long titles could not properly be forced onto more than one line in frameit. The font size just shrinks until the text fits onto a single line which usually produces small text and different font sizes for every screenshot.
--   Due to the multitude of brands and locales that we support, we had to offload frameit to our build server since running it locally and on demand turned out to be too slow.
--   The fact that frameit was built on top of imagemagick seemingly made it hard to easily address any of the above with a pull request.
+- No 3D placement of screenshots or support for multiple titles/screenshot in one framed image
+- Long titles could not properly be forced onto more than one line in frameit. The font size just shrinks until the text fits onto a single line which usually produces small text and different font sizes for every screenshot.
+- Due to the multitude of brands and locales that we support, we had to offload frameit to our build server since running it locally and on demand turned out to be too slow.
+- The fact that frameit was built on top of imagemagick seemingly made it hard to easily address any of the above with a pull request.

--- a/Sources/SwiftFrame/Render.swift
+++ b/Sources/SwiftFrame/Render.swift
@@ -1,0 +1,36 @@
+import ArgumentParser
+import Foundation
+import SwiftFrameCore
+
+struct Render: ParsableCommand {
+
+	@Argument(help: "Read configuration values from the specified file", completion: .list(["config", "json", "yml", "yaml"]))
+	var configFilePath: String
+
+	@Flag(name: .shortAndLong, help: "Prints additional information and lets you verify the config file before rendering")
+	var verbose = false
+
+	@Flag(name: .long)
+	var noManualValidation = false
+
+	@Flag(name: .long)
+	var noColorOutput = false
+
+	func run() throws {
+		let configFileURL = URL(fileURLWithPath: configFilePath)
+
+		do {
+			let processor = try ConfigProcessor(
+				configURL: configFileURL,
+				verbose: verbose,
+				noManualValidation: noManualValidation,
+				noColorOutput: noColorOutput
+			)
+			try processor.validate()
+			try processor.run()
+		} catch let error {
+			ky_exitWithError(error, verbose: verbose)
+		}
+	}
+
+}

--- a/Sources/SwiftFrame/Render.swift
+++ b/Sources/SwiftFrame/Render.swift
@@ -4,33 +4,33 @@ import SwiftFrameCore
 
 struct Render: ParsableCommand {
 
-	@Argument(help: "Read configuration values from the specified file", completion: .list(["config", "json", "yml", "yaml"]))
-	var configFilePath: String
+    @Argument(help: "Read configuration values from the specified file", completion: .list(["config", "json", "yml", "yaml"]))
+    var configFilePath: String
 
-	@Flag(name: .shortAndLong, help: "Prints additional information and lets you verify the config file before rendering")
-	var verbose = false
+    @Flag(name: .shortAndLong, help: "Prints additional information and lets you verify the config file before rendering")
+    var verbose = false
 
-	@Flag(name: .long)
-	var noManualValidation = false
+    @Flag(name: .long)
+    var noManualValidation = false
 
-	@Flag(name: .long)
-	var noColorOutput = false
+    @Flag(name: .long)
+    var noColorOutput = false
 
-	func run() throws {
-		let configFileURL = URL(fileURLWithPath: configFilePath)
+    func run() throws {
+        let configFileURL = URL(fileURLWithPath: configFilePath)
 
-		do {
-			let processor = try ConfigProcessor(
-				configURL: configFileURL,
-				verbose: verbose,
-				noManualValidation: noManualValidation,
-				noColorOutput: noColorOutput
-			)
-			try processor.validate()
-			try processor.run()
-		} catch let error {
-			ky_exitWithError(error, verbose: verbose)
-		}
-	}
+        do {
+            let processor = try ConfigProcessor(
+                configURL: configFileURL,
+                verbose: verbose,
+                noManualValidation: noManualValidation,
+                noColorOutput: noColorOutput
+            )
+            try processor.validate()
+            try processor.run()
+        } catch let error {
+            ky_exitWithError(error, verbose: verbose)
+        }
+    }
 
 }

--- a/Sources/SwiftFrame/Scaffold.swift
+++ b/Sources/SwiftFrame/Scaffold.swift
@@ -4,127 +4,127 @@ import SwiftFrameCore
 
 struct Scaffold: ParsableCommand, VerbosePrintable {
 
-	private static let defaultDevices = ["iPhoneX", "iPadPro12.9"]
+    private static let defaultDevices = ["iPhoneX", "iPadPro12.9"]
 
-	@Argument
-	var locales: [String]
+    @Argument
+    var locales: [String]
 
-	@Option(help: "The root of the directory where you want to create the scaffold in", completion: .directory)
-	var path: String?
+    @Option(help: "The root of the directory where you want to create the scaffold in", completion: .directory)
+    var path: String?
 
-	@Flag
-	var lowercasedDirectories = false
+    @Flag
+    var lowercasedDirectories = false
 
-	@Flag
-	var noHelperFiles = false
+    @Flag
+    var noHelperFiles = false
+    
+    @Flag
+    var verbose = false
 
-	@Flag
-	var verbose = false
+    // Using this computed property to be able to provide a nice flag name but still have a value
+    // to work with that is easily understandable semantically
+    private var shouldCreateHelperFiles: Bool {
+        !noHelperFiles
+    }
 
-	// Using this computed property to be able to provide a nice flag name but still have a value
-	// to work with that is easily understandable semantically
-	private var shouldCreateHelperFiles: Bool {
-		!noHelperFiles
-	}
+    func run() throws {
+        var numberOfCreatedDirectories = 0
+        var numberOfCreatedFiles = 0
 
-	func run() throws {
-		var numberOfCreatedDirectories = 0
-		var numberOfCreatedFiles = 0
+        let scaffoldRootURL = makeScaffoldRootURL()
+        let stringsDirectoryURL = scaffoldRootURL.appendingPathComponent("Strings".ky_lowercasedIfNeeded(lowercasedDirectories))
+        let screenshotsDirectoryURL = scaffoldRootURL.appendingPathComponent("Screenshots".ky_lowercasedIfNeeded(lowercasedDirectories))
+        let templatesDirectoryURL = scaffoldRootURL.appendingPathComponent("Templates".ky_lowercasedIfNeeded(lowercasedDirectories))
 
-		let scaffoldRootURL = makeScaffoldRootURL()
-		let stringsDirectoryURL = scaffoldRootURL.appendingPathComponent("Strings".ky_lowercasedIfNeeded(lowercasedDirectories))
-		let screenshotsDirectoryURL = scaffoldRootURL.appendingPathComponent("Screenshots".ky_lowercasedIfNeeded(lowercasedDirectories))
-		let templatesDirectoryURL = scaffoldRootURL.appendingPathComponent("Templates".ky_lowercasedIfNeeded(lowercasedDirectories))
+        let directoriesToCreate = [
+            scaffoldRootURL,
+            stringsDirectoryURL,
+            screenshotsDirectoryURL,
+            templatesDirectoryURL,
+        ]
 
-		let directoriesToCreate = [
-			scaffoldRootURL,
-			stringsDirectoryURL,
-			screenshotsDirectoryURL,
-			templatesDirectoryURL,
-		]
+        try directoriesToCreate.forEach { directory in
+            printVerbose("Creating directory \(directory.path)")
+            numberOfCreatedDirectories += 1
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+        }
 
-		try directoriesToCreate.forEach { directory in
-			printVerbose("Creating directory \(directory.path)")
-			numberOfCreatedDirectories += 1
-			try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
-		}
+        if shouldCreateHelperFiles {
+            let configFileURL = scaffoldRootURL.appendingPathComponent("config.json")
+            printVerbose("Creating empty config file \(configFileURL.path)")
+            try FileManager.default.ky_createFile(atURL: configFileURL, contents: nil, attributes: nil)
+            numberOfCreatedFiles += 1
+        }
 
-		if shouldCreateHelperFiles {
-			let configFileURL = scaffoldRootURL.appendingPathComponent("config.json")
-			printVerbose("Creating empty config file \(configFileURL.path)")
-			try FileManager.default.ky_createFile(atURL: configFileURL, contents: nil, attributes: nil)
-			numberOfCreatedFiles += 1
-		}
+        try locales.forEach { locale in
+            if shouldCreateHelperFiles {
+                let localeStringsFileContents = "\"some string key\" = \"the corresponding translation\";"
+                let localeStringsFileURL = stringsDirectoryURL.appendingPathComponent("\(locale).strings")
+                printVerbose("Creating string file at \(localeStringsFileURL.path)")
+                try FileManager.default.ky_writeToFile(localeStringsFileContents, destination: localeStringsFileURL)
+                numberOfCreatedFiles += 1
+            }
 
-		try locales.forEach { locale in
-			if shouldCreateHelperFiles {
-				let localeStringsFileContents = "\"some string key\" = \"the corresponding translation\";"
-				let localeStringsFileURL = stringsDirectoryURL.appendingPathComponent("\(locale).strings")
-				printVerbose("Creating string file at \(localeStringsFileURL.path)")
-				try FileManager.default.ky_writeToFile(localeStringsFileContents, destination: localeStringsFileURL)
-				numberOfCreatedFiles += 1
-			}
+            try Scaffold.defaultDevices.forEach { deviceName in
+                printVerbose("Creating screeenshot directory for locale \(locale) and device \(deviceName)")
+                numberOfCreatedDirectories += 1
+                
+                let localeScreenshotDirectoryURL = screenshotsDirectoryURL.appendingPathComponent(deviceName).appendingPathComponent(locale)
+                try FileManager.default.createDirectory(at: localeScreenshotDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+                
+                if shouldCreateHelperFiles {
+                    let markdownContents = "# \(deviceName) - \(locale)\n\nPlace your screenshots for \(deviceName) (\(locale)) in this folder\n" +
+                    "Please make sure that all screenshots that represent the same screen have the same name for every locale."
+                    try FileManager.default.ky_writeToFile(markdownContents, destination: localeScreenshotDirectoryURL.appendingPathComponent("README.md"))
+                    numberOfCreatedFiles += 1
+                }
+            }
+        }
 
-			try Scaffold.defaultDevices.forEach { deviceName in
-				printVerbose("Creating screeenshot directory for locale \(locale) and device \(deviceName)")
-				numberOfCreatedDirectories += 1
+        print("All done!")
+        print("Created \(numberOfCreatedDirectories) directories".formattedGreen())
+        print("Created \(numberOfCreatedFiles) files".formattedGreen())
+    }
 
-				let localeScreenshotDirectoryURL = screenshotsDirectoryURL.appendingPathComponent(deviceName).appendingPathComponent(locale)
-				try FileManager.default.createDirectory(at: localeScreenshotDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+    private func lowercasedDirectoryIfNeeded(_ string: String) -> String {
+        lowercasedDirectories ? string.lowercased() : string
+    }
 
-				if shouldCreateHelperFiles {
-					let markdownContents = "# \(deviceName) - \(locale)\n\nPlace your screenshots for \(deviceName) (\(locale)) in this folder\n" +
-					"Please make sure that all screenshots that represent the same screen have the same name for every locale."
-					try FileManager.default.ky_writeToFile(markdownContents, destination: localeScreenshotDirectoryURL.appendingPathComponent("README.md"))
-					numberOfCreatedFiles += 1
-				}
-			}
-		}
-
-		print("All done!")
-		print("Created \(numberOfCreatedDirectories) directories".formattedGreen())
-		print("Created \(numberOfCreatedFiles) files".formattedGreen())
-	}
-
-	private func lowercasedDirectoryIfNeeded(_ string: String) -> String {
-		lowercasedDirectories ? string.lowercased() : string
-	}
-
-	private func makeScaffoldRootURL() -> URL {
-		if let path = path {
-			return URL(fileURLWithPath: path)
-		} else {
-			return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-		}
-	}
+    private func makeScaffoldRootURL() -> URL {
+        if let path = path {
+            return URL(fileURLWithPath: path)
+        } else {
+            return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        }
+    }
 
 }
 
 extension FileManager {
 
-	func ky_writeToFile(_ contents: String, destination: URL) throws {
-		guard let data = contents.data(using: .utf8) else {
-			throw NSError(description: "Could not encode string using UTF-8")
-		}
-		try ky_createFile(atURL: destination, contents: data, attributes: nil)
-	}
+    func ky_writeToFile(_ contents: String, destination: URL) throws {
+        guard let data = contents.data(using: .utf8) else {
+            throw NSError(description: "Could not encode string using UTF-8")
+        }
+        try ky_createFile(atURL: destination, contents: data, attributes: nil)
+    }
 
-	func ky_createFile(atURL url: URL, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
-		try ky_createFile(atPath: url.path, contents: contents, attributes: attributes)
-	}
+    func ky_createFile(atURL url: URL, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
+        try ky_createFile(atPath: url.path, contents: contents, attributes: attributes)
+    }
 
-	func ky_createFile(atPath path: String, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
-		if !createFile(atPath: path, contents: contents, attributes: attributes) {
-			throw NSError(description: "Could not create file at path \(path)")
-		}
-	}
+    func ky_createFile(atPath path: String, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
+        if !createFile(atPath: path, contents: contents, attributes: attributes) {
+            throw NSError(description: "Could not create file at path \(path)")
+        }
+    }
 
 }
 
 extension String {
 
-	func ky_lowercasedIfNeeded(_ shouldUseLowercase: Bool) -> String {
-		shouldUseLowercase ? self.lowercased() : self
-	}
+    func ky_lowercasedIfNeeded(_ shouldUseLowercase: Bool) -> String {
+        shouldUseLowercase ? self.lowercased() : self
+    }
 
 }

--- a/Sources/SwiftFrame/Scaffold.swift
+++ b/Sources/SwiftFrame/Scaffold.swift
@@ -66,7 +66,7 @@ struct Scaffold: ParsableCommand, VerbosePrintable {
             }
 
             try Scaffold.defaultDevices.forEach { deviceName in
-                printVerbose("Creating screeenshot directory for locale \(locale) and device \(deviceName)")
+                printVerbose("Creating screenshot directory for locale \(locale) and device \(deviceName)")
                 numberOfCreatedDirectories += 1
                 
                 let localeScreenshotDirectoryURL = screenshotsDirectoryURL.appendingPathComponent(deviceName).appendingPathComponent(locale)
@@ -95,27 +95,6 @@ struct Scaffold: ParsableCommand, VerbosePrintable {
             return URL(fileURLWithPath: path)
         } else {
             return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        }
-    }
-
-}
-
-extension FileManager {
-
-    func ky_writeToFile(_ contents: String, destination: URL) throws {
-        guard let data = contents.data(using: .utf8) else {
-            throw NSError(description: "Could not encode string using UTF-8")
-        }
-        try ky_createFile(atURL: destination, contents: data, attributes: nil)
-    }
-
-    func ky_createFile(atURL url: URL, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
-        try ky_createFile(atPath: url.path, contents: contents, attributes: attributes)
-    }
-
-    func ky_createFile(atPath path: String, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
-        if !createFile(atPath: path, contents: contents, attributes: attributes) {
-            throw NSError(description: "Could not create file at path \(path)")
         }
     }
 

--- a/Sources/SwiftFrame/Scaffold.swift
+++ b/Sources/SwiftFrame/Scaffold.swift
@@ -1,0 +1,130 @@
+import ArgumentParser
+import Foundation
+import SwiftFrameCore
+
+struct Scaffold: ParsableCommand, VerbosePrintable {
+
+	private static let defaultDevices = ["iPhoneX", "iPadPro12.9"]
+
+	@Argument
+	var locales: [String]
+
+	@Option(help: "The root of the directory where you want to create the scaffold in", completion: .directory)
+	var path: String?
+
+	@Flag
+	var lowercasedDirectories = false
+
+	@Flag
+	var noHelperFiles = false
+
+	@Flag
+	var verbose = false
+
+	// Using this computed property to be able to provide a nice flag name but still have a value
+	// to work with that is easily understandable semantically
+	private var shouldCreateHelperFiles: Bool {
+		!noHelperFiles
+	}
+
+	func run() throws {
+		var numberOfCreatedDirectories = 0
+		var numberOfCreatedFiles = 0
+
+		let scaffoldRootURL = makeScaffoldRootURL()
+		let stringsDirectoryURL = scaffoldRootURL.appendingPathComponent("Strings".ky_lowercasedIfNeeded(lowercasedDirectories))
+		let screenshotsDirectoryURL = scaffoldRootURL.appendingPathComponent("Screenshots".ky_lowercasedIfNeeded(lowercasedDirectories))
+		let templatesDirectoryURL = scaffoldRootURL.appendingPathComponent("Templates".ky_lowercasedIfNeeded(lowercasedDirectories))
+
+		let directoriesToCreate = [
+			scaffoldRootURL,
+			stringsDirectoryURL,
+			screenshotsDirectoryURL,
+			templatesDirectoryURL,
+		]
+
+		try directoriesToCreate.forEach { directory in
+			printVerbose("Creating directory \(directory.path)")
+			numberOfCreatedDirectories += 1
+			try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+		}
+
+		if shouldCreateHelperFiles {
+			let configFileURL = scaffoldRootURL.appendingPathComponent("config.json")
+			printVerbose("Creating empty config file \(configFileURL.path)")
+			try FileManager.default.ky_createFile(atURL: configFileURL, contents: nil, attributes: nil)
+			numberOfCreatedFiles += 1
+		}
+
+		try locales.forEach { locale in
+			if shouldCreateHelperFiles {
+				let localeStringsFileContents = "\"some string key\" = \"the corresponding translation\";"
+				let localeStringsFileURL = stringsDirectoryURL.appendingPathComponent("\(locale).strings")
+				printVerbose("Creating string file at \(localeStringsFileURL.path)")
+				try FileManager.default.ky_writeToFile(localeStringsFileContents, destination: localeStringsFileURL)
+				numberOfCreatedFiles += 1
+			}
+
+			try Scaffold.defaultDevices.forEach { deviceName in
+				printVerbose("Creating screeenshot directory for locale \(locale) and device \(deviceName)")
+				numberOfCreatedDirectories += 1
+
+				let localeScreenshotDirectoryURL = screenshotsDirectoryURL.appendingPathComponent(deviceName).appendingPathComponent(locale)
+				try FileManager.default.createDirectory(at: localeScreenshotDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+
+				if shouldCreateHelperFiles {
+					let markdownContents = "# \(deviceName) - \(locale)\n\nPlace your screenshots for \(deviceName) (\(locale)) in this folder\n" +
+					"Please make sure that all screenshots that represent the same screen have the same name for every locale."
+					try FileManager.default.ky_writeToFile(markdownContents, destination: localeScreenshotDirectoryURL.appendingPathComponent("README.md"))
+					numberOfCreatedFiles += 1
+				}
+			}
+		}
+
+		print("All done!")
+		print("Created \(numberOfCreatedDirectories) directories".formattedGreen())
+		print("Created \(numberOfCreatedFiles) files".formattedGreen())
+	}
+
+	private func lowercasedDirectoryIfNeeded(_ string: String) -> String {
+		lowercasedDirectories ? string.lowercased() : string
+	}
+
+	private func makeScaffoldRootURL() -> URL {
+		if let path = path {
+			return URL(fileURLWithPath: path)
+		} else {
+			return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+		}
+	}
+
+}
+
+extension FileManager {
+
+	func ky_writeToFile(_ contents: String, destination: URL) throws {
+		guard let data = contents.data(using: .utf8) else {
+			throw NSError(description: "Could not encode string using UTF-8")
+		}
+		try ky_createFile(atURL: destination, contents: data, attributes: nil)
+	}
+
+	func ky_createFile(atURL url: URL, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
+		try ky_createFile(atPath: url.path, contents: contents, attributes: attributes)
+	}
+
+	func ky_createFile(atPath path: String, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
+		if !createFile(atPath: path, contents: contents, attributes: attributes) {
+			throw NSError(description: "Could not create file at path \(path)")
+		}
+	}
+
+}
+
+extension String {
+
+	func ky_lowercasedIfNeeded(_ shouldUseLowercase: Bool) -> String {
+		shouldUseLowercase ? self.lowercased() : self
+	}
+
+}

--- a/Sources/SwiftFrame/SwiftFrame.swift
+++ b/Sources/SwiftFrame/SwiftFrame.swift
@@ -8,7 +8,7 @@ struct SwiftFrame: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "swiftframe",
         abstract: "CLI application for speedy screenshot framing",
-        version: "4.0.1",
+        version: "4.1.0",
         subcommands: [Render.self, Scaffold.self],
         defaultSubcommand: Render.self,
         helpNames: .shortAndLong

--- a/Sources/SwiftFrame/SwiftFrame.swift
+++ b/Sources/SwiftFrame/SwiftFrame.swift
@@ -2,17 +2,16 @@ import ArgumentParser
 import Foundation
 import SwiftFrameCore
 
+@main
 struct SwiftFrame: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "swiftframe",
         abstract: "CLI application for speedy screenshot framing",
         version: "4.0.1",
-		subcommands: [Render.self, Scaffold.self],
-		defaultSubcommand: Render.self,
+        subcommands: [Render.self, Scaffold.self],
+        defaultSubcommand: Render.self,
         helpNames: .shortAndLong
     )
 
 }
-
-SwiftFrame.main()

--- a/Sources/SwiftFrame/main.swift
+++ b/Sources/SwiftFrame/main.swift
@@ -8,37 +8,10 @@ struct SwiftFrame: ParsableCommand {
         commandName: "swiftframe",
         abstract: "CLI application for speedy screenshot framing",
         version: "4.0.1",
+		subcommands: [Render.self, Scaffold.self],
+		defaultSubcommand: Render.self,
         helpNames: .shortAndLong
     )
-
-    @Argument(help: "Read configuration values from the specified file", completion: .list(["config", "json", "yml", "yaml"]))
-    var configFilePath: String
-
-    @Flag(name: .shortAndLong, help: "Prints additional information and lets you verify the config file before rendering")
-    var verbose = false
-
-    @Flag(name: .long)
-    var noManualValidation = false
-
-    @Flag(name: .long)
-    var noColorOutput = false
-
-    func run() throws {
-        let configFileURL = URL(fileURLWithPath: configFilePath)
-
-        do {
-            let processor = try ConfigProcessor(
-                configURL: configFileURL,
-                verbose: verbose,
-                noManualValidation: noManualValidation,
-                noColorOutput: noColorOutput
-            )
-            try processor.validate()
-            try processor.run()
-        } catch let error {
-            ky_exitWithError(error, verbose: verbose)
-        }
-    }
 
 }
 

--- a/Sources/SwiftFrameCore/Extensions/FileManager+Extensions.swift
+++ b/Sources/SwiftFrameCore/Extensions/FileManager+Extensions.swift
@@ -7,7 +7,7 @@ extension FileManager {
             .filter { pathExtension == nil ? true : $0.pathExtension == pathExtension }
     }
 
-    // Doesn't throw if the directory doesn't exist or another error occured
+    // Doesn't throw if the directory doesn't exist or another error occurred
     func ky_unsafeFilesAtPath(_ url: URL) -> [URL] {
         do {
             return try ky_filesAtPath(url)
@@ -32,6 +32,23 @@ extension FileManager {
             try mappedURLs.forEach {
                 try removeItem(at: $0)
             }
+        }
+    }
+
+    public func ky_writeToFile(_ contents: String, destination: URL) throws {
+        guard let data = contents.data(using: .utf8) else {
+            throw NSError(description: "Could not encode string using UTF-8")
+        }
+        try ky_createFile(atURL: destination, contents: data, attributes: nil)
+    }
+
+    public func ky_createFile(atURL url: URL, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
+        try ky_createFile(atPath: url.path, contents: contents, attributes: attributes)
+    }
+
+    public func ky_createFile(atPath path: String, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
+        if !createFile(atPath: path, contents: contents, attributes: attributes) {
+            throw NSError(description: "Could not create file at path \(path)")
         }
     }
 


### PR DESCRIPTION
This PR introduces a new subcommand to SwiftFrame. Its usage is documented in `README.md`. Other changes include the usage of `@main` since we now have more than one file in the SwiftFrame folder, which also means the file doesn't have to be named `main.swift` anymore. No changes were made to the rendering process or parsing, also the render process can still be invoked using `swiftframe -c path/to/configuration/file` so no new major version should be required

Closes #25