### PR TITLE
Update title font NSAttributedString generation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ With this flag SwiftFrame will not create sample files for each locale/device. O
 
 Will print some additional information, for example how many folders and files were created
 
+## Notes
+
+We offer rudimentary markup support for your strings with HTML tags such as <b>, <i> or <u>. In order to use this, please make sure the font file you pass in uses the .ttc format, is installed on your computer and has all the versions you need.
+
 ## Why not frameit?
 
 Fastlane's [frameit](https://github.com/fastlane/fastlane/tree/master/frameit) is an awesome tool but we have, unfortunately, found it to be too limitting for our own needs. At the time of writing this, the following reasons drove us towards implementing a stand-alone solution:

--- a/Sources/SwiftFrameCore/Extensions/String+Extensions.swift
+++ b/Sources/SwiftFrameCore/Extensions/String+Extensions.swift
@@ -12,7 +12,7 @@ extension String {
     }
     
     func ky_containsHTMLTags() -> Bool {
-        let regex = try! NSRegularExpression(pattern: "<(.*)>.*?|<(.*) />")
+        let regex = try! NSRegularExpression(pattern: "<(.*)>.*?|<(.*)/>")
         let range = NSRange(location: 0, length: (self as NSString).length)
         return regex.firstMatch(in: self, options: [], range: range) != nil
     }

--- a/Sources/SwiftFrameCore/Extensions/String+Extensions.swift
+++ b/Sources/SwiftFrameCore/Extensions/String+Extensions.swift
@@ -10,6 +10,12 @@ extension String {
     func formattedRed() -> String {
         CommandLineFormatter.formatWithColorIfNeeded(self, color: .red)
     }
+    
+    func ky_containsHTMLTags() -> Bool {
+        let regex = try! NSRegularExpression(pattern: "<(.*)>.*?|<(.*) />")
+        let range = NSRange(location: 0, length: (self as NSString).length)
+        return regex.firstMatch(in: self, options: [], range: range) != nil
+    }
 
     public func ky_data(using encoding: String.Encoding = .utf8) throws -> Data {
         guard let data = self.data(using: encoding, allowLossyConversion: false) else {

--- a/Sources/SwiftFrameCore/Workers/TextRenderer.swift
+++ b/Sources/SwiftFrameCore/Workers/TextRenderer.swift
@@ -117,14 +117,29 @@ final class TextRenderer {
     }
 
     // MARK: - Misc
+    
+    static func makeAttributedString(for string: String, font: NSFont, color: NSColor = .white, alignment: TextAlignment) throws -> NSAttributedString {
+        let attributedString: NSMutableAttributedString
+        // Currently the HTML tag support is limited, and the font information is only carried over if the font is provided using the .ttc format
+        // and the font is installed on the computer. Hence only using the HTML parsing if the string contains HTML tags
+        if string.ky_containsHTMLTags() {
+            attributedString = try makeHTMLAttributedString(for: string, font: font, color: color)
+        } else {
+            attributedString = NSMutableAttributedString(
+                string: string,
+                attributes: [.font: font, .foregroundColor: color]
+            )
+        }
+        attributedString.setAlignment(alignment.horizontal.nsAlignment, range: NSRange(location: 0, length: attributedString.length))
+        return attributedString
+    }
 
-    static func makeAttributedString(for htmlString: String, font: NSFont, color: NSColor = .white, alignment: TextAlignment) throws -> NSAttributedString {
+    private static func makeHTMLAttributedString(for htmlString: String, font: NSFont, color: NSColor = .white) throws -> NSMutableAttributedString {
         let htmlString = makeHTMLFormattedString(for: htmlString, font: font, color: color)
         guard let stringData = htmlString.data(using: .utf8) else {
             throw NSError(description: "Could not make attributed string for string \"\(htmlString)\"")
         }
         let attributedString = try NSMutableAttributedString.ky_makeFromHTMLData(stringData)
-        attributedString.setAlignment(alignment.horizontal.nsAlignment, range: NSRange(location: 0, length: attributedString.length))
         return attributedString
     }
 

--- a/Tests/SwiftFrameTests/ExtensionTests.swift
+++ b/Tests/SwiftFrameTests/ExtensionTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import SwiftFrameCore
+
+class ExtensionTests: XCTestCase {
+    
+    func testStringWithHTMLTagsIsFlagged() {
+        let testString1 = "This is a <b>test</b>"
+        let testString2 = "This is a <i>test</i>"
+        let testString3 = "This <i>is a<i/> <b>test</b>"
+        
+        XCTAssertTrue(testString1.ky_containsHTMLTags())
+        XCTAssertTrue(testString2.ky_containsHTMLTags())
+        XCTAssertTrue(testString3.ky_containsHTMLTags())
+    }
+    
+    func testStringWithoutHTMLTagsIsNotFlagged() {
+        let testString1 = "This is a test"
+        let testString2 = "1 < 3 means one is smaller than three"
+        let testString3 = "3 > 1 means three is larger than one"
+        let testString4 = "This i> kind of looks like html tags, but is not </ "
+        
+        XCTAssertFalse(testString1.ky_containsHTMLTags())
+        XCTAssertFalse(testString2.ky_containsHTMLTags())
+        XCTAssertFalse(testString3.ky_containsHTMLTags())
+        XCTAssertFalse(testString4.ky_containsHTMLTags())
+    }
+
+}


### PR DESCRIPTION
- Only parse from HTML if the title string contains HTML tags
- Otherwise generate the attributed string using the regular attributes
- Update the README to better reflect when and how HTML markup is supported
This is to offer better support for custom fonts which are not installed