### PR TITLE
GH-30 Add new config flags and deprecation warnings

### DIFF
--- a/Example/example.config
+++ b/Example/example.config
@@ -1,5 +1,4 @@
 {
-  "clearDirectories": true,
   "format": "png",
   "stringsPath": "Example/Strings/",
   "maxFontSize": 140,
@@ -8,7 +7,6 @@
   ],
   "fontFile": "/System/Library/Fonts/HelveticaNeue.ttc",
   "textColor": "#FFF",
-  "outputWholeImage": true,
   "deviceData": [
     {
       "outputSuffixes": ["iPhone X 5.8 inches"],

--- a/Example/example.yaml
+++ b/Example/example.yaml
@@ -1,5 +1,4 @@
 ---
-clearDirectories: true
 format: png
 stringsPath: Example/Strings/
 maxFontSize: 140
@@ -7,7 +6,6 @@ outputPaths:
   - Example/Output/
 fontFile: "/System/Library/Fonts/HelveticaNeue.ttc"
 textColor: "#FFF"
-outputWholeImage: true
 deviceData:
   - outputSuffixes:
         - iPhone X 5.8 inches

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ However, if you'd like you can also build SwiftFrame from source. To do this clo
 -   change into the directory: `cd SwiftFrame`
 -   run the install script: `sh install.sh`
 
-## Usage
+## Rendering Images
 
 To use SwiftFrame, you need to pass it a configuration file (which is a JSON or YAML file):
 
@@ -32,29 +32,31 @@ To use SwiftFrame, you need to pass it a configuration file (which is a JSON or 
 swiftframe path/to/your/config/file --verbose
 ```
 
-### Available Options
+### Opt-In Flags
+
+You can use the `--help` flag to print SwiftFrame's documentation out. The following flags are available
 
 #### --verbose
 
 Prints additional information during processing and rendering. This will also ask you to confirm the processed config file before SwiftFrame starts rendering
 
-#### --no-color-output
+#### --manual-validation
 
-Disables colored output. Useful for CI logs for example
-
-#### --no-manual-validation
-
-Disables the manual validation that requires you to confirm the parsed config file by pressing a key. Only useful in combination with `--verbose`
-
-#### --clear-directories
-
-Clears any output directory before writing images to prevent leftover images to remain in the directories
+Pauses after parsing the config file to let you verify the contents
 
 #### --output-whole-image
 
 Outputs the whole image canvas into the output directories before slicing it up into the correct screenshot sizes. Helpful for troubleshooting
 
-You can also use the `--help` flag to print SwiftFrame's documentation out
+### Opt-Out Flags
+
+#### --color-output/--no-color-output
+
+Controls whether logged output will be colored or now. Useful for CI logs for example. Default is **true**
+
+#### --clear-directories/--no-clear-directories
+
+Controls whether output directories will be cleared before writing images to them. Default is **true**
 
 ## Configuration File
 
@@ -66,8 +68,6 @@ The format of the configuration file is specified as following (indent levels re
 -   `fontFile`: a path to a font file
 -   `format`: the output format of the screenshots, can be `png`, `jpeg` or `jpg`
 -   `textColor`: a RGB color in Hex format (e.g. `#FFF`) to use for titles
--   `outputWholeImage`: **optional (default: false)** a boolean telling the application whether or not to also output the whole image instead of just the sliced up screenshots. **DEPRECATED: parsing will be removed in a future version**
--   `clearDirectories`: **optional (default: true)** a boolean telling the application whether or not to clear the specified output directories before writing new files to it. This prevents random screenshots from being used in case you update your template file to include one less screenshot for example. **DEPRECATED: parsing will be removed in a future version**
 -   `locales`: **optional** a regular expression that can be used to exclude (or include) certain locales during rendering. To only include `fr` and `de` locale for example, use `"fr|de"`. To exclude `ru` and `fr`, use something like `"^(?!ru|fr$)\\w*$"`
 -   `deviceData`: an array containing device specific data about screenshot and text coordinates (this way you can frame screenshots for more than one device per config file)
     -   `outputSuffixes`: an array of suffixes to apply to the output files in addition to the locale identifier and index. Multiple suffixes can be used to render the same screenshots for different target devices (for example 2nd and 3rd 12.9 inch iPad Pro)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Disables colored output. Useful for CI logs for example
 
 Disables the manual validation that requires you to confirm the parsed config file by pressing a key. Only useful in combination with `--verbose`
 
+#### --clear-directories
+
+Clears any output directory before writing images to prevent leftover images to remain in the directories
+
+#### --output-whole-image
+
+Outputs the whole image canvas into the output directories before slicing it up into the correct screenshot sizes. Helpful for troubleshooting
+
 You can also use the `--help` flag to print SwiftFrame's documentation out
 
 ## Configuration File
@@ -58,8 +66,8 @@ The format of the configuration file is specified as following (indent levels re
 -   `fontFile`: a path to a font file
 -   `format`: the output format of the screenshots, can be `png`, `jpeg` or `jpg`
 -   `textColor`: a RGB color in Hex format (e.g. `#FFF`) to use for titles
--   `outputWholeImage`: **optional (default: false)** a boolean telling the application whether or not to also output the whole image instead of just the sliced up screenshots
--   `clearDirectories`: **optional (default: true)** a boolean telling the application whether or not to clear the specified output directories before writing new files to it. This prevents random screenshots from being used in case you update your template file to include one less screenshot for example
+-   `outputWholeImage`: **optional (default: false)** a boolean telling the application whether or not to also output the whole image instead of just the sliced up screenshots. **DEPRECATED: parsing will be removed in a future version**
+-   `clearDirectories`: **optional (default: true)** a boolean telling the application whether or not to clear the specified output directories before writing new files to it. This prevents random screenshots from being used in case you update your template file to include one less screenshot for example. **DEPRECATED: parsing will be removed in a future version**
 -   `locales`: **optional** a regular expression that can be used to exclude (or include) certain locales during rendering. To only include `fr` and `de` locale for example, use `"fr|de"`. To exclude `ru` and `fr`, use something like `"^(?!ru|fr$)\\w*$"`
 -   `deviceData`: an array containing device specific data about screenshot and text coordinates (this way you can frame screenshots for more than one device per config file)
     -   `outputSuffixes`: an array of suffixes to apply to the output files in addition to the locale identifier and index. Multiple suffixes can be used to render the same screenshots for different target devices (for example 2nd and 3rd 12.9 inch iPad Pro)

--- a/README.md
+++ b/README.md
@@ -32,31 +32,27 @@ To use SwiftFrame, you need to pass it a configuration file (which is a JSON or 
 swiftframe path/to/your/config/file --verbose
 ```
 
-### Opt-In Flags
-
 You can use the `--help` flag to print SwiftFrame's documentation out. The following flags are available
 
-#### --verbose
+### --verbose
 
 Prints additional information during processing and rendering. This will also ask you to confirm the processed config file before SwiftFrame starts rendering
 
-#### --manual-validation
+### --manual-validation
 
 Pauses after parsing the config file to let you verify the contents
 
-#### --output-whole-image
+### --output-whole-image
 
 Outputs the whole image canvas into the output directories before slicing it up into the correct screenshot sizes. Helpful for troubleshooting
 
-### Opt-Out Flags
+### --no-color-output
 
-#### --color-output/--no-color-output
+Disables any colored output. Useful when running in CI
 
-Controls whether logged output will be colored or now. Useful for CI logs for example. Default is **true**
+### --no-clear-directories
 
-#### --clear-directories/--no-clear-directories
-
-Controls whether output directories will be cleared before writing images to them. Default is **true**
+Disables clearing the output directories before writing images to them
 
 ## Configuration File
 

--- a/Sources/SwiftFrame/Render.swift
+++ b/Sources/SwiftFrame/Render.swift
@@ -10,11 +10,20 @@ struct Render: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Prints additional information and lets you verify the config file before rendering")
     var verbose = false
 
-    @Flag(name: .long)
+    @Flag(name: .long, help: "Skips the manual validation step if --verbose/-v is used")
     var noManualValidation = false
 
-    @Flag(name: .long)
+    @Flag(name: .long, help: "Disables any colored output")
     var noColorOutput = false
+
+    @Flag(name: .long, help: "Clears any output directory before writing images to prevent leftover images to remain in the directories")
+    var clearDirectories = false
+
+    @Flag(
+        name: .long,
+        help: "Outputs the whole image canvas into the output directories before slicing it up into the correct screenshot sizes. Helpful for troubleshooting"
+    )
+    var outputWholeImage = false
 
     func run() throws {
         let configFileURL = URL(fileURLWithPath: configFilePath)
@@ -24,6 +33,8 @@ struct Render: ParsableCommand {
                 configURL: configFileURL,
                 verbose: verbose,
                 noManualValidation: noManualValidation,
+                outputWholeImage: outputWholeImage,
+                clearDirectories: clearDirectories,
                 noColorOutput: noColorOutput
             )
             try processor.validate()

--- a/Sources/SwiftFrame/Render.swift
+++ b/Sources/SwiftFrame/Render.swift
@@ -12,7 +12,7 @@ struct Render: ParsableCommand {
     )
     var configFilePath: String
 
-    // MARK: - Opt-In Features
+    // MARK: - Flags
 
     @Flag(
         name: .shortAndLong,
@@ -32,21 +32,17 @@ struct Render: ParsableCommand {
     )
     var outputWholeImage = false
 
-    // MARK: - Opt-Out Features
+    @Flag(
+        name: .long,
+        help: "Disables any colored output. Useful when running in CI"
+    )
+    var noColorOutput = false
 
     @Flag(
         name: .long,
-        inversion: .prefixedNo,
-        help: "Controls whether logged output will be colored or now"
+        help: "Disables clearing the output directories before writing images to them"
     )
-    var colorOutput = true
-
-    @Flag(
-        name: .long,
-        inversion: .prefixedNo,
-        help: "Controls whether output directories will be cleared before writing images to them"
-    )
-    var clearDirectories = true
+    var noClearDirectories = false
 
     // MARK: - Run
 
@@ -59,8 +55,8 @@ struct Render: ParsableCommand {
                 verbose: verbose,
                 shouldValidateManually: manualValidation,
                 shouldOutputWholeImage: outputWholeImage,
-                shouldClearDirectories: clearDirectories,
-                shouldColorOutput: colorOutput
+                shouldClearDirectories: !noClearDirectories,
+                shouldColorOutput: !noColorOutput
             )
             try processor.validate()
             try processor.run()

--- a/Sources/SwiftFrame/Render.swift
+++ b/Sources/SwiftFrame/Render.swift
@@ -4,26 +4,51 @@ import SwiftFrameCore
 
 struct Render: ParsableCommand {
 
-    @Argument(help: "Read configuration values from the specified file", completion: .list(["config", "json", "yml", "yaml"]))
+    // MARK: - Arguments
+
+    @Argument(
+        help: "Read configuration values from the specified file",
+        completion: .list(["config", "json", "yml", "yaml"])
+    )
     var configFilePath: String
 
-    @Flag(name: .shortAndLong, help: "Prints additional information and lets you verify the config file before rendering")
+    // MARK: - Opt-In Features
+
+    @Flag(
+        name: .shortAndLong,
+        help: "Prints additional information and lets you verify the config file before rendering"
+    )
     var verbose = false
 
-    @Flag(name: .long, help: "Skips the manual validation step if --verbose/-v is used")
-    var noManualValidation = false
-
-    @Flag(name: .long, help: "Disables any colored output")
-    var noColorOutput = false
-
-    @Flag(name: .long, help: "Clears any output directory before writing images to prevent leftover images to remain in the directories")
-    var clearDirectories = false
+    @Flag(
+        name: .long,
+        help: "Pauses after parsing the config file to let you verify the contents"
+    )
+    var manualValidation = false
 
     @Flag(
         name: .long,
         help: "Outputs the whole image canvas into the output directories before slicing it up into the correct screenshot sizes. Helpful for troubleshooting"
     )
     var outputWholeImage = false
+
+    // MARK: - Opt-Out Features
+
+    @Flag(
+        name: .long,
+        inversion: .prefixedNo,
+        help: "Controls whether logged output will be colored or now"
+    )
+    var colorOutput = true
+
+    @Flag(
+        name: .long,
+        inversion: .prefixedNo,
+        help: "Controls whether output directories will be cleared before writing images to them"
+    )
+    var clearDirectories = true
+
+    // MARK: - Run
 
     func run() throws {
         let configFileURL = URL(fileURLWithPath: configFilePath)
@@ -32,10 +57,10 @@ struct Render: ParsableCommand {
             let processor = try ConfigProcessor(
                 configURL: configFileURL,
                 verbose: verbose,
-                noManualValidation: noManualValidation,
-                outputWholeImage: outputWholeImage,
-                clearDirectories: clearDirectories,
-                noColorOutput: noColorOutput
+                shouldValidateManually: manualValidation,
+                shouldOutputWholeImage: outputWholeImage,
+                shouldClearDirectories: clearDirectories,
+                shouldColorOutput: colorOutput
             )
             try processor.validate()
             try processor.run()

--- a/Sources/SwiftFrame/SwiftFrame.swift
+++ b/Sources/SwiftFrame/SwiftFrame.swift
@@ -8,7 +8,7 @@ struct SwiftFrame: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "swiftframe",
         abstract: "CLI application for speedy screenshot framing",
-        version: "4.1.2",
+        version: "4.2.0",
         subcommands: [Render.self, Scaffold.self],
         defaultSubcommand: Render.self,
         helpNames: .shortAndLong

--- a/Sources/SwiftFrame/SwiftFrame.swift
+++ b/Sources/SwiftFrame/SwiftFrame.swift
@@ -8,7 +8,7 @@ struct SwiftFrame: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "swiftframe",
         abstract: "CLI application for speedy screenshot framing",
-        version: "4.2.0",
+        version: "5.0.0",
         subcommands: [Render.self, Scaffold.self],
         defaultSubcommand: Render.self,
         helpNames: .shortAndLong

--- a/Sources/SwiftFrameCore/Config/ConfigData.swift
+++ b/Sources/SwiftFrameCore/Config/ConfigData.swift
@@ -20,9 +20,9 @@ struct ConfigData: Decodable, ConfigValidateable {
     let textColorSource: ColorSource
     let outputFormat: FileFormat
     let localesRegex: String?
+    let clearDirectories: Bool?
+    let outputWholeImage: Bool?
 
-    @DecodableDefault.True var clearDirectories: Bool
-    @DecodableDefault.False var outputWholeImage: Bool
     @DecodableDefault.EmptyList var textGroups: [TextGroup]
 
     internal private(set) var deviceData: [DeviceData]
@@ -54,8 +54,8 @@ struct ConfigData: Decodable, ConfigValidateable {
         fontSource: FontSource,
         textColorSource: ColorSource,
         outputFormat: FileFormat,
-        clearDirectories: Bool,
-        outputWholeImage: Bool,
+        clearDirectories: Bool?,
+        outputWholeImage: Bool?,
         deviceData: [DeviceData],
         localesRegex: String? = nil)
     {
@@ -92,6 +92,22 @@ struct ConfigData: Decodable, ConfigValidateable {
     // MARK: - ConfigValidateable
 
     public func validate() throws {
+        if clearDirectories != nil {
+            let warningMessage = """
+            Specifying clearDirectories in the config file is deprecated and will be ignored in a future version.
+            Please use the CLI argument --clear-directories instead.
+            """
+            print(CommandLineFormatter.formatWarning(text: warningMessage))
+        }
+
+        if outputWholeImage != nil {
+            let warningMessage = """
+            Specifying outputWholeImage in the config file is deprecated and will be ignored in a future version.
+            Please use the CLI argument --output-whole-image instead.
+            """
+            print(CommandLineFormatter.formatWarning(text: warningMessage))
+        }
+
         guard !deviceData.isEmpty else {
             throw NSError(
                 description: "No screenshot data was supplied",

--- a/Sources/SwiftFrameCore/Workers/CommandLineFormatter.swift
+++ b/Sources/SwiftFrameCore/Workers/CommandLineFormatter.swift
@@ -35,7 +35,7 @@ public final class CommandLineFormatter {
     }
 
     class func formatWithColorIfNeeded(_ message: String, color: Color) -> String {
-        if ConfigProcessor.noColorOutput {
+        if ConfigProcessor.shouldColorOutput {
             return message
         } else {
             return [color.escapeSequence, message, Color.default.escapeSequence].joined()

--- a/Sources/SwiftFrameCore/Workers/CommandLineFormatter.swift
+++ b/Sources/SwiftFrameCore/Workers/CommandLineFormatter.swift
@@ -36,9 +36,9 @@ public final class CommandLineFormatter {
 
     class func formatWithColorIfNeeded(_ message: String, color: Color) -> String {
         if ConfigProcessor.shouldColorOutput {
-            return message
-        } else {
             return [color.escapeSequence, message, Color.default.escapeSequence].joined()
+        } else {
+            return message
         }
     }
 

--- a/Sources/SwiftFrameCore/Workers/ConfigProcessor.swift
+++ b/Sources/SwiftFrameCore/Workers/ConfigProcessor.swift
@@ -5,12 +5,13 @@ public class ConfigProcessor: VerbosePrintable {
 
     // MARK: - Properties
 
-    static var noColorOutput = true
+    static var shouldColorOutput = true
 
     public let verbose: Bool
-    private let noManualValidation: Bool
-    private let outputWholeImage: Bool
-    private let clearDirectories: Bool
+
+    private let shouldValidateManually: Bool
+    private let shouldOutputWholeImage: Bool
+    private let shouldClearDirectories: Bool
 
     private var data: ConfigData
 
@@ -19,17 +20,17 @@ public class ConfigProcessor: VerbosePrintable {
     public init(
         configURL: URL,
         verbose: Bool,
-        noManualValidation: Bool,
-        outputWholeImage: Bool,
-        clearDirectories: Bool,
-        noColorOutput: Bool) throws
+        shouldValidateManually: Bool,
+        shouldOutputWholeImage: Bool,
+        shouldClearDirectories: Bool,
+        shouldColorOutput: Bool) throws
     {
         data = try DecodableParser.parseData(fromURL: configURL)
         self.verbose = verbose
-        self.noManualValidation = noManualValidation
-        self.outputWholeImage = outputWholeImage
-        self.clearDirectories = clearDirectories
-        ConfigProcessor.noColorOutput = noColorOutput
+        self.shouldValidateManually = shouldValidateManually
+        self.shouldOutputWholeImage = shouldOutputWholeImage
+        self.shouldClearDirectories = shouldClearDirectories
+        ConfigProcessor.shouldColorOutput = shouldColorOutput
     }
 
     // MARK: - Methods
@@ -38,19 +39,11 @@ public class ConfigProcessor: VerbosePrintable {
         try process()
         try data.validate()
 
-        if data.outputWholeImage != nil, outputWholeImage {
-            let warningMessage = """
-            ouputWholeImage was specified both in the config file and as a CLI argument.
-            The value from the config file will be prioritised until its removal
-            """
-            print(CommandLineFormatter.formatWarning(text: warningMessage))
+        if data.outputWholeImage != nil {
+            printDeprecationWarning(for: "ouputWholeImage")
         }
-        if data.clearDirectories != nil, clearDirectories {
-            let warningMessage = """
-            clearDirectories was specified both in the config file and as a CLI argument.
-            The value from the config file will be prioritised until its removal
-            """
-            print(CommandLineFormatter.formatWarning(text: warningMessage))
+        if data.clearDirectories != nil {
+            printDeprecationWarning(for: "clearDirectories")
         }
     }
 
@@ -59,7 +52,7 @@ public class ConfigProcessor: VerbosePrintable {
     }
 
     public func run() throws {
-        if verbose && !noManualValidation {
+        if shouldValidateManually {
             data.printSummary(insetByTabs: 0)
             print("Press return key to continue")
             _ = readLine()
@@ -67,7 +60,7 @@ public class ConfigProcessor: VerbosePrintable {
 
         print("Parsed and validated config file\n")
 
-        if data.clearDirectories ?? clearDirectories {
+        if shouldClearDirectories {
             let clearingStart = CFAbsoluteTimeGetCurrent()
             try FileManager.default.ky_clearDirectories(data.outputPaths, localeFolders: Array(data.titles.keys))
             printElapsedTime("Clear output directories", startTime: clearingStart)
@@ -137,7 +130,7 @@ public class ConfigProcessor: VerbosePrintable {
                 with: data.outputPaths,
                 sliceSize: sliceSize,
                 gapWidth: deviceData.gapWidth,
-                outputWholeImage: data.outputWholeImage ?? outputWholeImage,
+                outputWholeImage: shouldOutputWholeImage,
                 locale: locale,
                 suffixes: deviceData.outputSuffixes,
                 format: data.outputFormat
@@ -151,6 +144,13 @@ public class ConfigProcessor: VerbosePrintable {
         }
 
         group.wait()
+    }
+
+    // MARK: - Helpers
+
+    private func printDeprecationWarning(for configProperty: String) {
+        let warningMessage = "\(configProperty) was specified in the config file, which is deprecated. The value will be ignored"
+        print(CommandLineFormatter.formatWarning(text: warningMessage))
     }
 
 }

--- a/benchmark.py
+++ b/benchmark.py
@@ -2,71 +2,58 @@
 
 import atexit
 import subprocess
+import sys
 import time
 from distutils.dir_util import copy_tree
 from os import path
 from pathlib import Path
 from shutil import copy2, rmtree
 
-locales = ['en',
-           'fr-FR',
-           'de-DE',
-           'sv',
-           'no',
-           'pl',
-           'br-PT',
-           'it',
-           'ja',
-           'ro',
-           'th',
-           'tr',
-           'uk',
-           'vi'
-           ]
-benchmark_config_file = 'Benchmark/example.config'
+LOCALES = ["en", "fr-FR", "de-DE", "sv", "no", "pl", "br-PT", "it", "ja", "ro", "th", "tr", "uk", "vi"]
+BENCHMARK_CONFIG_FILE = "Benchmark/example.config"
 
 # Setup exit handler
 
 
 @atexit.register
 def exit_handler():
-    rmtree('Benchmark/')
+    rmtree("Benchmark/")
 
 
 # Create directory if needed
 print("Setting up benchmark directory")
 
-Path('Benchmark/').mkdir(parents=True, exist_ok=True)
-Path('Benchmark/Strings').mkdir(parents=True, exist_ok=True)
+Path("Benchmark/").mkdir(parents=True, exist_ok=True)
+Path("Benchmark/Strings").mkdir(parents=True, exist_ok=True)
 
 # Replace `Example` with `Benchmark` in config file
-with open('Example/example.config', 'rt') as fin:
-    with open(benchmark_config_file, 'wt') as fout:
+with open("Example/example.config", "rt", encoding="utf-8") as fin:
+    with open(BENCHMARK_CONFIG_FILE, "wt", encoding="utf-8") as fout:
         for line in fin:
-            fout.write(line.replace('Example', 'Benchmark'))
+            fout.write(line.replace("Example", "Benchmark"))
 
 # Copy template files
-template_files_folder = 'Example/Template Files/'
-copy_tree(template_files_folder, 'Benchmark/Template Files/')
+TEMPLATE_FILES_FOLDER = "Example/Template Files/"
+copy_tree(TEMPLATE_FILES_FOLDER, "Benchmark/Template Files/")
 
 # Copying over screenshots and titles
-for locale in locales:
-    print(f'Copying files for {locale}')
-    for device in ["iPhone X", 'iPad Pro']:
-        screenshot_source_folder = f'Example/Screenshots/{device}/en'
-        screenshot_target_folder = f'Benchmark/Screenshots/{device}/{locale}'
+for locale in LOCALES:
+    print(f"Copying files for {locale}")
+    for device in ["iPhone X", "iPad Pro"]:
+        screenshot_source_folder = f"Example/Screenshots/{device}/en"
+        screenshot_target_folder = f"Benchmark/Screenshots/{device}/{locale}"
         copy_tree(screenshot_source_folder, screenshot_target_folder)
 
-    string_source_file = 'Example/Strings/en.strings'
-    string_destination_file = f'Benchmark/Strings/{locale}.strings'
-    copy2(string_source_file, string_destination_file)
+    STRING_SOURCE_FILE = "Example/Strings/en.strings"
+    STRING_DESTINATION_FILE = f"Benchmark/Strings/{locale}.strings"
+    copy2(STRING_SOURCE_FILE, STRING_DESTINATION_FILE)
 
 # Clear .build directory
 if path.exists(".build"):
-    rmtree('.build')
+    rmtree(".build")
 
 # Compile SwiftFrame
-compile_process = subprocess.run('swift build -c release', shell=True)
+compile_process = subprocess.run("swift build -c release", shell=True, check=True)
 
 if compile_process.returncode != 0:
     exit(compile_process.returncode)
@@ -74,10 +61,11 @@ if compile_process.returncode != 0:
 # Running benchmark
 benchmark_start = time.time()
 run_process = subprocess.run(
-    '.build/release/swiftframe Benchmark/example.config --verbose --no-manual-validation', shell=True)
+    ".build/release/swiftframe Benchmark/example.config --verbose --output-whole-image", shell=True, check=True
+)
 benchmark_end = time.time()
 
 if run_process.returncode != 0:
-    exit(compile_process.returncode)
+    sys.exit(compile_process.returncode)
 
-print(f'Benchmark finished in {benchmark_end - benchmark_start}s')
+print(f"Benchmark finished in {benchmark_end - benchmark_start}s")


### PR DESCRIPTION
## Context

We want to move `outputWholeImage` and `clearOutputDirectories` out of the config files and have them as CLI arguments instead. Initially I had made changes that would be non-breaking and that would instead detect if `--output-whole-image` and/or `--clear-directories` were specified in addition to their config file equivalents. If yes, a deprecation message was printed, but for now the value from the config file was prioritised (if both were specified). However, the more I thought about it the less the naming of the existing flags made sense to me in my head. That's why I suggest simply moving to v5.0.0 which gives us the freedom to introduce breaking changes. The changes I suggest are the following:

## Changes

- separated flags by opt-in and opt-out 
- The default value for opt-in flags is `false` and it will only become `true` if you explicitly specify the flag (therefore opt-in). Opt-in flags are `-v/--verbose`, `--manual-validation` and `--output-whole-image`
- Opt-out flags have a default value of `true` and have **two** associated flags. One with their actual name and one prefixed with `no`. Opt-out flags are `--color-output/--no-color-output` and `--clear-directories/--no-clear-directories`
- Changed behavior or verbose mode in the sense it no longer goes hand in hand with manual validation. `-v/--verbose` now only has a single purpose which is to enable debug logging
- Manual validation is now controlled by specifying `--manual-validation`, which can be used independently of verbose mode
- made parsing of `outputWholeImage` and `clearDirectories` from config files optional and instead created two new flags
- added a validation step to check if `outputWholeImage` and `clearDirectories` are still specified in the config files and if yes, output a warning that they will be ignored. I'm not sure if we really need that if we introduce a new major version anyways, so open to suggestions
- renamed a lot of internal variables to better match the Swift naming convention (most of them named something like `shouldDoXXX`)
- updated config files
- updated README files to document the new flags and remove the old config file keys
- update the `benchmark.py` script to use the CLI flags
- reformat benchmark script using `black` formatter and fixed issues surfaced by linter

Closes #30