### PR TITLE
#33 swift-format changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,17 +13,17 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0")
+        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
     ],
     targets: [
         .executableTarget(
             name: "SwiftFrame",
             dependencies: [
                 "SwiftFrameCore",
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]
         ),
         .target(name: "SwiftFrameCore", dependencies: ["Yams"]),
-        .testTarget(name: "SwiftFrameTests", dependencies: ["SwiftFrameCore"])
+        .testTarget(name: "SwiftFrameTests", dependencies: ["SwiftFrameCore"]),
     ]
 )

--- a/Sources/SwiftFrame/Render.swift
+++ b/Sources/SwiftFrame/Render.swift
@@ -28,7 +28,8 @@ struct Render: ParsableCommand {
 
     @Flag(
         name: .long,
-        help: "Outputs the whole image canvas into the output directories before slicing it up into the correct screenshot sizes. Helpful for troubleshooting"
+        help:
+            "Outputs the whole image canvas into the output directories before slicing it up into the correct screenshot sizes. Helpful for troubleshooting"
     )
     var outputWholeImage = false
 

--- a/Sources/SwiftFrame/Scaffold.swift
+++ b/Sources/SwiftFrame/Scaffold.swift
@@ -17,7 +17,7 @@ struct Scaffold: ParsableCommand, VerbosePrintable {
 
     @Flag
     var noHelperFiles = false
-    
+
     @Flag
     var verbose = false
 
@@ -43,7 +43,7 @@ struct Scaffold: ParsableCommand, VerbosePrintable {
             templatesDirectoryURL,
         ]
 
-        try directoriesToCreate.forEach { directory in
+        for directory in directoriesToCreate {
             printVerbose("Creating directory \(directory.path)")
             numberOfCreatedDirectories += 1
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
@@ -56,7 +56,7 @@ struct Scaffold: ParsableCommand, VerbosePrintable {
             numberOfCreatedFiles += 1
         }
 
-        try locales.forEach { locale in
+        for locale in locales {
             if shouldCreateHelperFiles {
                 let localeStringsFileContents = "\"some string key\" = \"the corresponding translation\";"
                 let localeStringsFileURL = stringsDirectoryURL.appendingPathComponent("\(locale).strings")
@@ -65,17 +65,25 @@ struct Scaffold: ParsableCommand, VerbosePrintable {
                 numberOfCreatedFiles += 1
             }
 
-            try Scaffold.defaultDevices.forEach { deviceName in
+            for deviceName in Scaffold.defaultDevices {
                 printVerbose("Creating screenshot directory for locale \(locale) and device \(deviceName)")
                 numberOfCreatedDirectories += 1
-                
+
                 let localeScreenshotDirectoryURL = screenshotsDirectoryURL.appendingPathComponent(deviceName).appendingPathComponent(locale)
-                try FileManager.default.createDirectory(at: localeScreenshotDirectoryURL, withIntermediateDirectories: true, attributes: nil)
-                
+                try FileManager.default.createDirectory(
+                    at: localeScreenshotDirectoryURL,
+                    withIntermediateDirectories: true,
+                    attributes: nil
+                )
+
                 if shouldCreateHelperFiles {
-                    let markdownContents = "# \(deviceName) - \(locale)\n\nPlace your screenshots for \(deviceName) (\(locale)) in this folder\n" +
-                    "Please make sure that all screenshots that represent the same screen have the same name for every locale."
-                    try FileManager.default.ky_writeToFile(markdownContents, destination: localeScreenshotDirectoryURL.appendingPathComponent("README.md"))
+                    let markdownContents =
+                        "# \(deviceName) - \(locale)\n\nPlace your screenshots for \(deviceName) (\(locale)) in this folder\n"
+                        + "Please make sure that all screenshots that represent the same screen have the same name for every locale."
+                    try FileManager.default.ky_writeToFile(
+                        markdownContents,
+                        destination: localeScreenshotDirectoryURL.appendingPathComponent("README.md")
+                    )
                     numberOfCreatedFiles += 1
                 }
             }

--- a/Sources/SwiftFrameCore/Config/ScreenshotData.swift
+++ b/Sources/SwiftFrameCore/Config/ScreenshotData.swift
@@ -32,7 +32,8 @@ struct ScreenshotData: Decodable, ConfigValidateable, Equatable {
             bottomRight: bottomRight.convertingToBottomLeftOrigin(withSize: size),
             topLeft: topLeft.convertingToBottomLeftOrigin(withSize: size),
             topRight: topRight.convertingToBottomLeftOrigin(withSize: size),
-            zIndex: zIndex)
+            zIndex: zIndex
+        )
     }
 
     // MARK: - ConfigValidateable

--- a/Sources/SwiftFrameCore/Config/TextData.swift
+++ b/Sources/SwiftFrameCore/Config/TextData.swift
@@ -48,8 +48,8 @@ struct TextData: Decodable, ConfigValidateable {
         groupIdentifier: String?,
         topLeft: Point,
         bottomRight: Point,
-        textColorOverride: NSColor? = nil)
-    {
+        textColorOverride: NSColor? = nil
+    ) {
         self.titleIdentifier = titleIdentifier
         self.textAlignment = textAlignment
         self.maxFontSizeOverride = maxFontSizeOverride
@@ -77,7 +77,8 @@ struct TextData: Decodable, ConfigValidateable {
             groupIdentifier: groupIdentifier,
             topLeft: processedTopLeft,
             bottomRight: processedBottomRight,
-            textColorOverride: colorOverride)
+            textColorOverride: colorOverride
+        )
     }
 
     // MARK: - ConfigValidateable

--- a/Sources/SwiftFrameCore/Config/TextGroup.swift
+++ b/Sources/SwiftFrameCore/Config/TextGroup.swift
@@ -29,14 +29,16 @@ struct TextGroup: Decodable, ConfigValidateable, Hashable {
 
     func sharedFontSize(with strings: [AssociatedString], globalFont: NSFont, globalMaxSize: CGFloat) throws -> CGFloat {
         let maxFontSizes: [CGFloat] = try strings.compactMap {
-            return try TextRenderer.maximumFontSizeThatFits(
+            try TextRenderer.maximumFontSizeThatFits(
                 string: $0.string,
                 font: $0.data.fontOverride?.font() ?? globalFont,
                 alignment: $0.data.textAlignment,
                 maxSize: $0.data.maxFontSizeOverride ?? globalMaxSize,
-                size: $0.data.rect.size)
+                size: $0.data.rect.size
+            )
         }
         // Can force-unwrap since array will never be empty
+        // swift-format-ignore: NeverForceUnwrap
         return ([globalMaxSize, maxFontSize] + maxFontSizes).min()!
     }
 }

--- a/Sources/SwiftFrameCore/Extensions/FileManager+Extensions.swift
+++ b/Sources/SwiftFrameCore/Extensions/FileManager+Extensions.swift
@@ -15,13 +15,13 @@ extension FileManager {
     }
 
     func ky_clearDirectories(_ urls: [FileURL], localeFolders: [String]) throws {
-        try urls.forEach { url in
+        for url in urls {
             let mappedURLs: [URL] = localeFolders.compactMap {
                 let mappedURL = url.absoluteURL.appendingPathComponent($0)
                 return fileExists(atPath: mappedURL.path) ? mappedURL : nil
             }
-            try mappedURLs.forEach {
-                try removeItem(at: $0)
+            for url in mappedURLs {
+                try removeItem(at: url)
             }
         }
     }
@@ -33,11 +33,11 @@ extension FileManager {
         try ky_createFile(atURL: destination, contents: data, attributes: nil)
     }
 
-    public func ky_createFile(atURL url: URL, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
+    public func ky_createFile(atURL url: URL, contents: Data?, attributes: [FileAttributeKey: Any]? = nil) throws {
         try ky_createFile(atPath: url.path, contents: contents, attributes: attributes)
     }
 
-    public func ky_createFile(atPath path: String, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) throws {
+    public func ky_createFile(atPath path: String, contents: Data?, attributes: [FileAttributeKey: Any]? = nil) throws {
         if !createFile(atPath: path, contents: contents, attributes: attributes) {
             throw NSError(description: "Could not create file at path \(path)")
         }

--- a/Sources/SwiftFrameCore/Extensions/NSError+Extensions.swift
+++ b/Sources/SwiftFrameCore/Extensions/NSError+Extensions.swift
@@ -1,27 +1,27 @@
 import Foundation
 
-public extension NSError {
+extension NSError {
 
     private static let kExpectationKey = "kExpectationKey"
     private static let kActualValueKey = "kActualValueKey"
 
-    convenience init(code: Int = 1, description: String, expectation: String? = nil, actualValue: String? = nil) {
+    public convenience init(code: Int = 1, description: String, expectation: String? = nil, actualValue: String? = nil) {
         self.init(
             domain: "com.kayak.SwiftFrame",
             code: code,
             userInfo: [
                 NSLocalizedDescriptionKey: description,
                 NSError.kExpectationKey: expectation as Any,
-                NSError.kActualValueKey: actualValue as Any
+                NSError.kActualValueKey: actualValue as Any,
             ]
         )
     }
 
-    var expectation: String? {
+    public var expectation: String? {
         userInfo[NSError.kExpectationKey] as? String
     }
 
-    var actualValue: String? {
+    public var actualValue: String? {
         userInfo[NSError.kActualValueKey] as? String
     }
 

--- a/Sources/SwiftFrameCore/Extensions/NSFont+Extensions.swift
+++ b/Sources/SwiftFrameCore/Extensions/NSFont+Extensions.swift
@@ -4,7 +4,7 @@ import Foundation
 extension NSFont {
 
     func ky_toFont(ofSize size: CGFloat) -> NSFont {
-        return NSFontManager.shared.convert(self, toSize: size)
+        NSFontManager.shared.convert(self, toSize: size)
     }
 
 }

--- a/Sources/SwiftFrameCore/Extensions/String+Extensions.swift
+++ b/Sources/SwiftFrameCore/Extensions/String+Extensions.swift
@@ -6,9 +6,9 @@ extension String {
     public func formattedGreen() -> String {
         CommandLineFormatter.formatWithColorIfNeeded(self, color: .green)
     }
-    
-    func ky_containsHTMLTags() -> Bool {
-        let regex = try! NSRegularExpression(pattern: "<(.*)>.*?|<(.*)/>")
+
+    func ky_containsHTMLTags() throws -> Bool {
+        let regex = try NSRegularExpression(pattern: "<(.*)>.*?|<(.*)/>")
         let range = NSRange(location: 0, length: (self as NSString).length)
         return regex.firstMatch(in: self, options: [], range: range) != nil
     }

--- a/Sources/SwiftFrameCore/Extensions/URL+Extensions.swift
+++ b/Sources/SwiftFrameCore/Extensions/URL+Extensions.swift
@@ -4,7 +4,7 @@ import Foundation
 extension URL {
 
     var fileName: String {
-        return deletingPathExtension().lastPathComponent
+        deletingPathExtension().lastPathComponent
     }
 
     var subDirectories: [URL] {

--- a/Sources/SwiftFrameCore/Helper Types/DecodableDefault.swift
+++ b/Sources/SwiftFrameCore/Helper Types/DecodableDefault.swift
@@ -34,8 +34,8 @@ extension KeyedDecodingContainer {
 
     func decode<T>(
         _ type: DecodableDefault.Wrapper<T>.Type,
-        forKey key: Key) throws -> DecodableDefault.Wrapper<T>
-    {
+        forKey key: Key
+    ) throws -> DecodableDefault.Wrapper<T> {
         try decodeIfPresent(type, forKey: key) ?? .init()
     }
 

--- a/Sources/SwiftFrameCore/Helper Types/FileURL.swift
+++ b/Sources/SwiftFrameCore/Helper Types/FileURL.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Wrapper struct to avoid some errors related to relative paths
+/// Wrapper struct to avoid some errors related to relative paths.
 struct FileURL: Decodable {
 
     // MARK: - Properties

--- a/Sources/SwiftFrameCore/Helper Types/GraphicsContext.swift
+++ b/Sources/SwiftFrameCore/Helper Types/GraphicsContext.swift
@@ -8,12 +8,14 @@ class GraphicsContext {
     private let colorSpace: CGColorSpace
 
     lazy var ci: CIContext = {
-        CIContext(cgContext: cg, options: [
-            CIContextOption.workingColorSpace: colorSpace,
-            CIContextOption.useSoftwareRenderer: false
-        ])
+        CIContext(
+            cgContext: cg,
+            options: [
+                CIContextOption.workingColorSpace: colorSpace,
+                CIContextOption.useSoftwareRenderer: false,
+            ]
+        )
     }()
-
 
     init(size: CGSize) throws {
         let colorSpace = CGColorSpaceCreateDeviceRGB()

--- a/Sources/SwiftFrameCore/Helper Types/VerbosePrintable.swift
+++ b/Sources/SwiftFrameCore/Helper Types/VerbosePrintable.swift
@@ -6,9 +6,9 @@ public protocol VerbosePrintable {
 
 }
 
-public extension VerbosePrintable {
+extension VerbosePrintable {
 
-    func printVerbose(_ args: Any...) {
+    public func printVerbose(_ args: Any...) {
         guard verbose else {
             return
         }
@@ -19,7 +19,7 @@ public extension VerbosePrintable {
         print(printString.joined(separator: " "))
     }
 
-    func printElapsedTime(_ message: @autoclosure () -> String, startTime: CFAbsoluteTime) {
+    public func printElapsedTime(_ message: @autoclosure () -> String, startTime: CFAbsoluteTime) {
         let timeElapsed = Double(CFAbsoluteTimeGetCurrent() - startTime)
         let messageString = message() + " completed in \(String(format: "%.02f", timeElapsed))s"
         printVerbose(CommandLineFormatter.formatTimeMeasurement(messageString))

--- a/Sources/SwiftFrameCore/Workers/CommandLineFormatter.swift
+++ b/Sources/SwiftFrameCore/Workers/CommandLineFormatter.swift
@@ -61,7 +61,8 @@ final class CommandLineFormatter {
 
 func ky_print(_ objects: Any..., insetByTabs tabs: Int) {
     let tabsString = String(repeating: CommandLineFormatter.tabsString, count: tabs)
-    let arguments = objects.count == 1
+    let arguments =
+        objects.count == 1
         ? String(describing: objects[0])
         : objects.map { String(describing: $0) }.joined(separator: " ")
     print(tabsString + arguments)

--- a/Sources/SwiftFrameCore/Workers/ConfigProcessor.swift
+++ b/Sources/SwiftFrameCore/Workers/ConfigProcessor.swift
@@ -57,8 +57,8 @@ public class ConfigProcessor: VerbosePrintable {
 
         let stringProcessingStart = CFAbsoluteTimeGetCurrent()
 
-        try data.deviceData.forEach { deviceData in
-            try deviceData.screenshotsGroupedByLocale.forEach { locale, _ in
+        for deviceData in data.deviceData {
+            for (locale, _) in deviceData.screenshotsGroupedByLocale {
                 printVerbose("Processing strings for locale \(locale) (\(deviceData.outputSuffixes.first ?? "unknown device"))")
 
                 let associatedStrings = try data.makeAssociatedStrings(for: deviceData, locale: locale)
@@ -97,7 +97,7 @@ public class ConfigProcessor: VerbosePrintable {
     private func process(deviceData: DeviceData) throws {
         let group = DispatchGroup()
 
-        try deviceData.screenshotsGroupedByLocale.forEach { locale, imageDict in
+        for (locale, imageDict) in deviceData.screenshotsGroupedByLocale {
             group.enter()
             defer { group.leave() }
 
@@ -128,7 +128,7 @@ public class ConfigProcessor: VerbosePrintable {
                 format: data.outputFormat
             )
 
-            deviceData.outputSuffixes.forEach { suffix in
+            for suffix in deviceData.outputSuffixes {
                 print("Finished \(locale)-\(suffix)")
             }
         }

--- a/Sources/SwiftFrameCore/Workers/ImageComposer.swift
+++ b/Sources/SwiftFrameCore/Workers/ImageComposer.swift
@@ -1,7 +1,7 @@
 import AppKit
-import Foundation
 import CoreGraphics
 import CoreImage
+import Foundation
 
 final class ImageComposer {
 
@@ -33,13 +33,13 @@ final class ImageComposer {
     // MARK: - Titles Rendering
 
     func addStrings(_ textData: [TextData], locale: String, deviceIdentifier: String) throws {
-        try textData.forEach {
+        for text in textData {
             try textRenderer.renderText(
-                forKey: $0.titleIdentifier,
+                forKey: text.titleIdentifier,
                 locale: locale,
                 deviceIdentifier: deviceIdentifier,
-                alignment: $0.textAlignment,
-                rect: $0.rect,
+                alignment: text.textAlignment,
+                rect: text.rect,
                 context: context
             )
         }
@@ -48,7 +48,7 @@ final class ImageComposer {
     // MARK: - Screenshots Rendering
 
     func add(screenshots: [String: URL], with screenshotData: [ScreenshotData], for locale: String) throws {
-        try screenshotData.forEach { data in
+        for data in screenshotData {
             guard let image = NSBitmapImageRep.ky_loadFromURL(screenshots[data.screenshotName]) else {
                 throw NSError(description: "Screenshot named \(data.screenshotName) not found in folder \"\(locale)\"")
             }

--- a/Sources/SwiftFrameCore/Workers/ImageWriter.swift
+++ b/Sources/SwiftFrameCore/Workers/ImageWriter.swift
@@ -13,8 +13,8 @@ final class ImageWriter {
         outputWholeImage: Bool,
         locale: String,
         suffixes: [String],
-        format: FileFormat) throws
-    {
+        format: FileFormat
+    ) throws {
         guard let image = context.cg.makeImage() else {
             throw NSError(description: "Could not render output image")
         }
@@ -49,9 +49,9 @@ final class ImageWriter {
 
     static func sliceImage(_ image: CGImage, with size: CGSize, gapWidth: Int) throws -> [CGImage] {
         let numberOfSlices = image.width / Int(size.width)
-        var croppedImages = [CGImage]()
+        var croppedImages: [CGImage] = []
 
-        for i in 0..<numberOfSlices {
+        for i in 0 ..< numberOfSlices {
             let rect = CGRect(x: (size.width * CGFloat(i)) + (CGFloat(gapWidth) * CGFloat(i)), y: 0, width: size.width, height: size.height)
             image.cropping(to: rect).flatMap { croppedImages.append($0) }
         }
@@ -85,8 +85,8 @@ final class ImageWriter {
             throw NSError(description: "Failed to convert image to \(format.fileExtension.uppercased())")
         }
 
-        try urls.forEach {
-            try data.ky_write(to: $0, options: .atomicWrite)
+        for url in urls {
+            try data.ky_write(to: url, options: .atomicWrite)
         }
     }
 
@@ -108,9 +108,9 @@ extension ImageWriter {
         // MARK: - Methods
 
         func makeBigImageOutputPaths() -> [URL] {
-            var urls = [URL]()
-            makeBasePaths().forEach { basePath in
-                suffixes.forEach { suffix in
+            var urls: [URL] = []
+            for basePath in makeBasePaths() {
+                for suffix in suffixes {
                     let url = basePath.appendingPathComponent("\(locale)-\(suffix)-big").appendingPathExtension(format.fileExtension)
                     urls.append(url)
                 }
@@ -119,10 +119,12 @@ extension ImageWriter {
         }
 
         func makeOutputPaths(for sliceIndex: Int) -> [URL] {
-            var urls = [URL]()
-            makeBasePaths().forEach { basePath in
-                suffixes.forEach { suffix in
-                    let url = basePath.appendingPathComponent("\(locale)-\(suffix)-\(sliceIndex)").appendingPathExtension(format.fileExtension)
+            var urls: [URL] = []
+            for basePath in makeBasePaths() {
+                for suffix in suffixes {
+                    let url = basePath.appendingPathComponent("\(locale)-\(suffix)-\(sliceIndex)").appendingPathExtension(
+                        format.fileExtension
+                    )
                     urls.append(url)
                 }
             }

--- a/Sources/SwiftFrameCore/Workers/ScreenshotRenderer.swift
+++ b/Sources/SwiftFrameCore/Workers/ScreenshotRenderer.swift
@@ -14,9 +14,14 @@ final class ScreenshotRenderer {
         context.cg.restoreGState()
     }
 
-    private func renderScreenshot(_ screenshot: NSBitmapImageRep, with data: ScreenshotData, in context: GraphicsContext) throws -> CGImage {
+    private func renderScreenshot(
+        _ screenshot: NSBitmapImageRep,
+        with data: ScreenshotData,
+        in context: GraphicsContext
+    ) throws -> CGImage {
         let ciImage = CIImage(bitmapImageRep: screenshot)
 
+        // swift-format-ignore: NeverForceUnwrap
         let perspectiveTransform = CIFilter(name: "CIPerspectiveTransform")!
         perspectiveTransform.setDefaults()
         perspectiveTransform.setValue(data.topLeft.ciVector, forKey: "inputTopLeft")
@@ -34,19 +39,20 @@ final class ScreenshotRenderer {
         return cgImage
     }
 
+    // swift-format-ignore: NeverForceUnwrap
     private func calculateRect(for screenshotData: ScreenshotData) -> NSRect {
         let xCoordinates = [
             screenshotData.bottomLeft.x,
             screenshotData.bottomRight.x,
             screenshotData.topLeft.x,
-            screenshotData.topRight.x
+            screenshotData.topRight.x,
         ]
 
         let yCoordinates = [
             screenshotData.bottomLeft.y,
             screenshotData.bottomRight.y,
             screenshotData.topLeft.y,
-            screenshotData.topRight.y
+            screenshotData.topRight.y,
         ]
 
         // Can force-unwrap since the are never empty

--- a/Sources/SwiftFrameCore/Workers/SliceSizeCalculator.swift
+++ b/Sources/SwiftFrameCore/Workers/SliceSizeCalculator.swift
@@ -13,7 +13,8 @@ struct SliceSizeCalculator {
         guard Int(templateWidthSubstractingGaps) >= numberOfSlices else {
             let minimumTemplateWidth = numberOfSlices + (totalGapWidthIfAny ?? 0)
             throw NSError(
-                description: "Template image is not wide enough to accommodate \(Pluralizer.pluralize(numberOfSlices, singular: "slice", plural: "slices"))",
+                description:
+                    "Template image is not wide enough to accommodate \(Pluralizer.pluralize(numberOfSlices, singular: "slice", plural: "slices"))",
                 expectation: "Template image should be at least \(minimumTemplateWidth) pixels wide",
                 actualValue: "Template image is \(templateImageSize.width) pixels wide"
             )

--- a/Sources/SwiftFrameCore/Workers/TextRenderer.swift
+++ b/Sources/SwiftFrameCore/Workers/TextRenderer.swift
@@ -8,8 +8,19 @@ final class TextRenderer {
 
     // MARK: - Frame Rendering
 
-    func renderText(forKey key: String, locale: String, deviceIdentifier: String, alignment: TextAlignment, rect: NSRect, context: GraphicsContext) throws {
-        let attributedString = try AttributedStringCache.shared.attributedString(forTitleIdentifier: key, locale: locale, deviceIdentifier: deviceIdentifier)
+    func renderText(
+        forKey key: String,
+        locale: String,
+        deviceIdentifier: String,
+        alignment: TextAlignment,
+        rect: NSRect,
+        context: GraphicsContext
+    ) throws {
+        let attributedString = try AttributedStringCache.shared.attributedString(
+            forTitleIdentifier: key,
+            locale: locale,
+            deviceIdentifier: deviceIdentifier
+        )
 
         context.cg.saveGState()
 
@@ -52,7 +63,9 @@ final class TextRenderer {
 
     /// Determines the maximum point size of the specified font that allows to render the given text onto a
     /// particular number of lines
-    static func maximumFontSizeThatFits(string: String, font: NSFont, alignment: TextAlignment, maxSize: CGFloat, size: CGSize) throws -> CGFloat {
+    static func maximumFontSizeThatFits(string: String, font: NSFont, alignment: TextAlignment, maxSize: CGFloat, size: CGSize) throws
+        -> CGFloat
+    {
         guard !string.isEmpty else {
             // Will be skipped during rendering anyways and won't affect text group's max size negatively, so it's okay to
             // return maxSize here
@@ -65,12 +78,20 @@ final class TextRenderer {
             alignment: alignment,
             minSize: TextRenderer.minFontSize,
             maxSize: maxSize,
-            size: size)
+            size: size
+        )
         // Subtract some small number to make absolutely sure text will be rendered completely
         return min(calculatedFontSize.rounded(.down), maxSize)
     }
 
-    private static func maxFontSizeThatFits(string: String, font: NSFont, alignment: TextAlignment, minSize: CGFloat, maxSize: CGFloat, size: CGSize) throws -> CGFloat {
+    private static func maxFontSizeThatFits(
+        string: String,
+        font: NSFont,
+        alignment: TextAlignment,
+        minSize: CGFloat,
+        maxSize: CGFloat,
+        size: CGSize
+    ) throws -> CGFloat {
         let fontSize = (minSize + maxSize) / 2
         let adaptedFont = font.ky_toFont(ofSize: fontSize)
 
@@ -92,9 +113,23 @@ final class TextRenderer {
         }
 
         if formattedString(attributedString, fitsIntoRect: size) {
-            return try maxFontSizeThatFits(string: string, font: adaptedFont, alignment: alignment, minSize: fontSize, maxSize: maxSize, size: size)
+            return try maxFontSizeThatFits(
+                string: string,
+                font: adaptedFont,
+                alignment: alignment,
+                minSize: fontSize,
+                maxSize: maxSize,
+                size: size
+            )
         } else {
-            return try maxFontSizeThatFits(string: string, font: adaptedFont, alignment: alignment, minSize: minSize, maxSize: fontSize, size: size)
+            return try maxFontSizeThatFits(
+                string: string,
+                font: adaptedFont,
+                alignment: alignment,
+                minSize: minSize,
+                maxSize: fontSize,
+                size: size
+            )
         }
     }
 
@@ -117,12 +152,14 @@ final class TextRenderer {
     }
 
     // MARK: - Misc
-    
-    static func makeAttributedString(for string: String, font: NSFont, color: NSColor = .white, alignment: TextAlignment) throws -> NSAttributedString {
+
+    static func makeAttributedString(for string: String, font: NSFont, color: NSColor = .white, alignment: TextAlignment) throws
+        -> NSAttributedString
+    {
         let attributedString: NSMutableAttributedString
         // Currently the HTML tag support is limited, and the font information is only carried over if the font is provided using the .ttc format
         // and the font is installed on the computer. Hence only using the HTML parsing if the string contains HTML tags
-        if string.ky_containsHTMLTags() {
+        if try string.ky_containsHTMLTags() {
             attributedString = try makeHTMLAttributedString(for: string, font: font, color: color)
         } else {
             attributedString = NSMutableAttributedString(
@@ -134,7 +171,9 @@ final class TextRenderer {
         return attributedString
     }
 
-    private static func makeHTMLAttributedString(for htmlString: String, font: NSFont, color: NSColor = .white) throws -> NSMutableAttributedString {
+    private static func makeHTMLAttributedString(for htmlString: String, font: NSFont, color: NSColor = .white) throws
+        -> NSMutableAttributedString
+    {
         let htmlString = makeHTMLFormattedString(for: htmlString, font: font, color: color)
         guard let stringData = htmlString.data(using: .utf8) else {
             throw NSError(description: "Could not make attributed string for string \"\(htmlString)\"")
@@ -149,7 +188,7 @@ final class TextRenderer {
         let attributes = [
             "font-family: \(font.fontName)",
             "font-size: \(Int(font.pointSize))",
-            "color: \(colorHexString)"
+            "color: \(colorHexString)",
         ]
 
         let constructedAttributes = attributes.joined(separator: "; ")
@@ -158,6 +197,6 @@ final class TextRenderer {
 
 }
 
-private func <=(lhs: CGSize, rhs: CGSize) -> Bool {
+private func <= (lhs: CGSize, rhs: CGSize) -> Bool {
     lhs.width <= rhs.width && lhs.height <= rhs.height
 }

--- a/Tests/SwiftFrameTests/ColorHexTests.swift
+++ b/Tests/SwiftFrameTests/ColorHexTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class ColorHexTests: XCTestCase {

--- a/Tests/SwiftFrameTests/Config Tests/ConfigDataTests.swift
+++ b/Tests/SwiftFrameTests/Config Tests/ConfigDataTests.swift
@@ -1,18 +1,19 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class ConfigDataTests: BaseTestCase {
 
     func testValidData() throws {
-        var data = ConfigData.goodData
+        var data = try ConfigData.goodData()
         try data.process()
 
         XCTAssertNoThrow(try data.validate())
     }
 
     func testSkippedLocalesData() throws {
-        var data = ConfigData.skippedLocaleData
+        var data = try ConfigData.skippedLocaleData()
         try data.process()
 
         XCTAssertNoThrow(try data.validate())
@@ -24,7 +25,7 @@ class ConfigDataTests: BaseTestCase {
     }
 
     func testEnglishOnlyData() throws {
-        var data = ConfigData.englishOnlyData
+        var data = try ConfigData.englishOnlyData()
         try data.process()
 
         XCTAssertNoThrow(try data.validate())
@@ -36,7 +37,7 @@ class ConfigDataTests: BaseTestCase {
     }
 
     func testInvalidData() throws {
-        var data = ConfigData.invalidData
+        var data = try ConfigData.invalidData()
         try data.process()
 
         XCTAssertThrowsError(try data.validate())

--- a/Tests/SwiftFrameTests/Config Tests/DeviceDataTests.swift
+++ b/Tests/SwiftFrameTests/Config Tests/DeviceDataTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class DeviceDataTests: BaseTestCase {

--- a/Tests/SwiftFrameTests/Config Tests/TextDataTests.swift
+++ b/Tests/SwiftFrameTests/Config Tests/TextDataTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class TextDataTests: BaseTestCase {

--- a/Tests/SwiftFrameTests/Config Tests/TextGroupTests.swift
+++ b/Tests/SwiftFrameTests/Config Tests/TextGroupTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class TextGroupTests: XCTestCase {

--- a/Tests/SwiftFrameTests/ExtensionTests.swift
+++ b/Tests/SwiftFrameTests/ExtensionTests.swift
@@ -1,29 +1,30 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class ExtensionTests: XCTestCase {
-    
-    func testStringWithHTMLTagsIsFlagged() {
+
+    func testStringWithHTMLTagsIsFlagged() throws {
         let testString1 = "This is a <b>test</b>"
         let testString2 = "This is a <i>test</i>"
         let testString3 = "This <i>is a<i/> <b>test</b>"
-        
-        XCTAssertTrue(testString1.ky_containsHTMLTags())
-        XCTAssertTrue(testString2.ky_containsHTMLTags())
-        XCTAssertTrue(testString3.ky_containsHTMLTags())
+
+        XCTAssertTrue(try testString1.ky_containsHTMLTags())
+        XCTAssertTrue(try testString2.ky_containsHTMLTags())
+        XCTAssertTrue(try testString3.ky_containsHTMLTags())
     }
-    
-    func testStringWithoutHTMLTagsIsNotFlagged() {
+
+    func testStringWithoutHTMLTagsIsNotFlagged() throws {
         let testString1 = "This is a test"
         let testString2 = "1 < 3 means one is smaller than three"
         let testString3 = "3 > 1 means three is larger than one"
         let testString4 = "This i> kind of looks like html tags, but is not </ "
-        
-        XCTAssertFalse(testString1.ky_containsHTMLTags())
-        XCTAssertFalse(testString2.ky_containsHTMLTags())
-        XCTAssertFalse(testString3.ky_containsHTMLTags())
-        XCTAssertFalse(testString4.ky_containsHTMLTags())
+
+        XCTAssertFalse(try testString1.ky_containsHTMLTags())
+        XCTAssertFalse(try testString2.ky_containsHTMLTags())
+        XCTAssertFalse(try testString3.ky_containsHTMLTags())
+        XCTAssertFalse(try testString4.ky_containsHTMLTags())
     }
 
 }

--- a/Tests/SwiftFrameTests/ImageComposerTests.swift
+++ b/Tests/SwiftFrameTests/ImageComposerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class ImageComposerTests: XCTestCase {

--- a/Tests/SwiftFrameTests/ImageLoaderTests.swift
+++ b/Tests/SwiftFrameTests/ImageLoaderTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class ImageLoaderTests: BaseTestCase {

--- a/Tests/SwiftFrameTests/PluralizerTests.swift
+++ b/Tests/SwiftFrameTests/PluralizerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class PluralizerTests: XCTestCase {

--- a/Tests/SwiftFrameTests/PointTests.swift
+++ b/Tests/SwiftFrameTests/PointTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class PointTests: XCTestCase {

--- a/Tests/SwiftFrameTests/RegexMatchTests.swift
+++ b/Tests/SwiftFrameTests/RegexMatchTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class RegexMatchTests: XCTestCase {
@@ -8,7 +9,7 @@ class RegexMatchTests: XCTestCase {
         URL(fileURLWithPath: "strings/en.strings"),
         URL(fileURLWithPath: "strings/de.strings"),
         URL(fileURLWithPath: "strings/fr.strings"),
-        URL(fileURLWithPath: "strings/ru.strings")
+        URL(fileURLWithPath: "strings/ru.strings"),
     ]
 
     func testAllURLs() throws {

--- a/Tests/SwiftFrameTests/ScreenshotRendererTests.swift
+++ b/Tests/SwiftFrameTests/ScreenshotRendererTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class ScreenshotRendererTests: XCTestCase {
@@ -15,7 +16,8 @@ class ScreenshotRendererTests: XCTestCase {
         try renderer.render(
             screenshot: rep,
             with: mockScreenshotData,
-            in: context)
+            in: context
+        )
     }
 
 }

--- a/Tests/SwiftFrameTests/SliceSizeCalculatorTests.swift
+++ b/Tests/SwiftFrameTests/SliceSizeCalculatorTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import SwiftFrameCore
 
 final class SliceSizeCalculatorTests: BaseTestCase {

--- a/Tests/SwiftFrameTests/TextRendererTests.swift
+++ b/Tests/SwiftFrameTests/TextRendererTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import SwiftFrameCore
 
 class TextRendererTests: XCTestCase {
@@ -11,7 +12,8 @@ class TextRendererTests: XCTestCase {
             font: NSFont.systemFont(ofSize: 200),
             alignment: TextAlignment(horizontal: .center, vertical: .top),
             maxSize: 400,
-            size: veryLargeSize)
+            size: veryLargeSize
+        )
 
         XCTAssertEqual(maxSize, 400)
     }
@@ -19,12 +21,15 @@ class TextRendererTests: XCTestCase {
     func testBoxTooSmall() {
         let smallSize = CGSize(width: 1, height: 1)
 
-        XCTAssertThrowsError(try TextRenderer.maximumFontSizeThatFits(
-            string: "Some testing string",
-            font: NSFont.systemFont(ofSize: 200),
-            alignment: TextAlignment(horizontal: .center, vertical: .top),
-            maxSize: 400,
-            size: smallSize))
+        XCTAssertThrowsError(
+            try TextRenderer.maximumFontSizeThatFits(
+                string: "Some testing string",
+                font: NSFont.systemFont(ofSize: 200),
+                alignment: TextAlignment(horizontal: .center, vertical: .top),
+                maxSize: 400,
+                size: smallSize
+            )
+        )
     }
 
     func testBottomAlignedRect() throws {
@@ -32,7 +37,11 @@ class TextRendererTests: XCTestCase {
         let size = CGSize(width: 60, height: 60)
         let rect = NSRect(x: 10, y: 10, width: 80, height: 80)
 
-        let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .bottom))
+        let alignedRect = try renderer.calculateAlignedRect(
+            size: size,
+            outerFrame: rect,
+            alignment: .init(horizontal: .center, vertical: .bottom)
+        )
 
         XCTAssertEqual(alignedRect.origin, rect.origin)
         XCTAssertEqual(alignedRect.height, size.height)
@@ -43,7 +52,11 @@ class TextRendererTests: XCTestCase {
         let size = CGSize(width: 60, height: 60)
         let rect = NSRect(x: 10, y: 10, width: 80, height: 80)
 
-        let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .top))
+        let alignedRect = try renderer.calculateAlignedRect(
+            size: size,
+            outerFrame: rect,
+            alignment: .init(horizontal: .center, vertical: .top)
+        )
 
         XCTAssertEqual(alignedRect.origin.y, rect.origin.y + (rect.height - alignedRect.height))
         XCTAssertEqual(alignedRect.height, size.height)
@@ -54,7 +67,11 @@ class TextRendererTests: XCTestCase {
         let size = CGSize(width: 60, height: 60)
         let rect = NSRect(x: 10, y: 10, width: 80, height: 80)
 
-        let alignedRect = try renderer.calculateAlignedRect(size: size, outerFrame: rect, alignment: .init(horizontal: .center, vertical: .center))
+        let alignedRect = try renderer.calculateAlignedRect(
+            size: size,
+            outerFrame: rect,
+            alignment: .init(horizontal: .center, vertical: .center)
+        )
 
         XCTAssertEqual(alignedRect.origin.y, rect.origin.y + ((rect.height - alignedRect.height) / 2))
         XCTAssertEqual(alignedRect.height, size.height)

--- a/Tests/SwiftFrameTests/Utility/ConfigDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/ConfigDataFixtures.swift
@@ -1,53 +1,62 @@
 import AppKit
 import Foundation
+
 @testable import SwiftFrameCore
 
 extension ConfigData {
 
-    static let goodData = ConfigData(
-        textGroups: [],
-        stringsPath: FileURL(path: "testing/strings/"),
-        maxFontSize: 200,
-        outputPaths: [FileURL(path: "testing/output/")],
-        fontSource: .nsFont(.systemFont(ofSize: 20)),
-        textColorSource: try! ColorSource(hexString: "#ff00ff"),
-        outputFormat: .png,
-        deviceData: [.validData()]
-    )
+    static func goodData() throws -> ConfigData {
+        ConfigData(
+            textGroups: [],
+            stringsPath: FileURL(path: "testing/strings/"),
+            maxFontSize: 200,
+            outputPaths: [FileURL(path: "testing/output/")],
+            fontSource: .nsFont(.systemFont(ofSize: 20)),
+            textColorSource: try ColorSource(hexString: "#ff00ff"),
+            outputFormat: .png,
+            deviceData: [.validData()]
+        )
+    }
 
-    static let skippedLocaleData = ConfigData(
-        textGroups: [],
-        stringsPath: FileURL(path: "testing/strings/"),
-        maxFontSize: 200,
-        outputPaths: [FileURL(path: "testing/output/")],
-        fontSource: .nsFont(.systemFont(ofSize: 20)),
-        textColorSource: try! ColorSource(hexString: "#ff00ff"),
-        outputFormat: .png,
-        deviceData: [.validData()],
-        localesRegex: "^(?!en|fr$)\\w*$"
-    )
+    static func skippedLocaleData() throws -> ConfigData {
+        ConfigData(
+            textGroups: [],
+            stringsPath: FileURL(path: "testing/strings/"),
+            maxFontSize: 200,
+            outputPaths: [FileURL(path: "testing/output/")],
+            fontSource: .nsFont(.systemFont(ofSize: 20)),
+            textColorSource: try ColorSource(hexString: "#ff00ff"),
+            outputFormat: .png,
+            deviceData: [.validData()],
+            localesRegex: "^(?!en|fr$)\\w*$"
+        )
+    }
 
-    static let englishOnlyData = ConfigData(
-        textGroups: [],
-        stringsPath: FileURL(path: "testing/strings/"),
-        maxFontSize: 200,
-        outputPaths: [FileURL(path: "testing/output/")],
-        fontSource: .nsFont(.systemFont(ofSize: 20)),
-        textColorSource: try! ColorSource(hexString: "#ff00ff"),
-        outputFormat: .png,
-        deviceData: [.validData()],
-        localesRegex: "en"
-    )
+    static func englishOnlyData() throws -> ConfigData {
+        ConfigData(
+            textGroups: [],
+            stringsPath: FileURL(path: "testing/strings/"),
+            maxFontSize: 200,
+            outputPaths: [FileURL(path: "testing/output/")],
+            fontSource: .nsFont(.systemFont(ofSize: 20)),
+            textColorSource: try ColorSource(hexString: "#ff00ff"),
+            outputFormat: .png,
+            deviceData: [.validData()],
+            localesRegex: "en"
+        )
+    }
 
-    static let invalidData = ConfigData(
-        textGroups: [],
-        stringsPath: FileURL(path: "testing/strings/"),
-        maxFontSize: 200,
-        outputPaths: [FileURL(path: "testing/output/")],
-        fontSource: .nsFont(.systemFont(ofSize: 20)),
-        textColorSource: try! ColorSource(hexString: "#ff00ff"),
-        outputFormat: .png,
-        deviceData: [.invalidTextData]
-    )
+    static func invalidData() throws -> ConfigData {
+        ConfigData(
+            textGroups: [],
+            stringsPath: FileURL(path: "testing/strings/"),
+            maxFontSize: 200,
+            outputPaths: [FileURL(path: "testing/output/")],
+            fontSource: .nsFont(.systemFont(ofSize: 20)),
+            textColorSource: try ColorSource(hexString: "#ff00ff"),
+            outputFormat: .png,
+            deviceData: [.invalidTextData]
+        )
+    }
 
 }

--- a/Tests/SwiftFrameTests/Utility/DeviceDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/DeviceDataFixtures.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 @testable import SwiftFrameCore
 
 extension DeviceData {

--- a/Tests/SwiftFrameTests/Utility/ScreenshotDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/ScreenshotDataFixtures.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 @testable import SwiftFrameCore
 
 extension ScreenshotData {

--- a/Tests/SwiftFrameTests/Utility/TestHelpers.swift
+++ b/Tests/SwiftFrameTests/Utility/TestHelpers.swift
@@ -36,6 +36,7 @@ extension CGContext {
     func makePlainWhiteImageRep() -> NSBitmapImageRep {
         setFillColor(.white)
         fill(NSRect(x: 0, y: 0, width: width, height: height))
+        // swift-format-ignore: NeverForceUnwrap
         return NSBitmapImageRep(cgImage: makeImage()!)
     }
 

--- a/Tests/SwiftFrameTests/Utility/TestingUtility.swift
+++ b/Tests/SwiftFrameTests/Utility/TestingUtility.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 @testable import SwiftFrameCore
 
 typealias JSONDictionary = [String: Encodable]
@@ -31,12 +32,12 @@ struct TestingUtility {
     static func setupMockDirectoryWithScreenshots(gapWidth: Int = 0) throws {
         let devices = ["debug_device1", "debug_device2"]
         let locales = ["en", "de", "fr"]
-        try devices.forEach { device in
+        for device in devices {
             try writeMockTemplateFile(deviceSuffix: device, gapWidth: gapWidth)
         }
 
-        try locales.forEach { locale in
-            try devices.forEach { deviceString in
+        for locale in locales {
+            for deviceString in devices {
                 try writeMockScreenshot(locale: locale, deviceSuffix: deviceString)
             }
         }
@@ -53,8 +54,8 @@ struct TestingUtility {
     static func writeStringFiles(for locales: [String]) throws {
         let fileContent = StringFilesContainer.goodData.makeStringFileContent()
 
-        try locales.forEach {
-            let filePath = URL(fileURLWithPath: "testing/strings/\($0).strings")
+        for locale in locales {
+            let filePath = URL(fileURLWithPath: "testing/strings/\(locale).strings")
             let data = try fileContent.ky_data(using: .utf8)
 
             try data.ky_write(to: filePath)

--- a/Tests/SwiftFrameTests/Utility/TextDataFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/TextDataFixtures.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+
 @testable import SwiftFrameCore
 
 extension TextData {

--- a/Tests/SwiftFrameTests/Utility/TextGroupFixtures.swift
+++ b/Tests/SwiftFrameTests/Utility/TextGroupFixtures.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+
 @testable import SwiftFrameCore
 
 extension TextGroup {

--- a/swift-format.json
+++ b/swift-format.json
@@ -22,7 +22,7 @@
   "rules": {
     "AllPublicDeclarationsHaveDocumentation": false,
     "AlwaysUseLiteralForEmptyCollectionInit": true,
-    "AlwaysUseLowerCamelCase": true,
+    "AlwaysUseLowerCamelCase": false,
     "AmbiguousTrailingClosureOverload": true,
     "BeginDocumentationCommentWithOneLineSummary": true,
     "DoNotUseSemicolons": true,


### PR DESCRIPTION
## Context

This PR adds all the changes produced by running `swift-format`, as well as manually resolved linter complaints

## Changes

- ran `Scripts/format-swift-code` and committed changes
- manually changed all `something.forEach { element in` to `for element in something {`
- resolved some force trys
- ignored some safe force unwraps by using `// swift-format-ignore: ...`